### PR TITLE
add temperature parameter for scaling confidences

### DIFF
--- a/include/caffe/layers/softmax_layer.hpp
+++ b/include/caffe/layers/softmax_layer.hpp
@@ -39,10 +39,15 @@ class SoftmaxLayer : public Layer<Dtype> {
   int outer_num_;
   int inner_num_;
   int softmax_axis_;
+  bool temperature_scaling_;
+  Dtype temperature_;
   /// sum_multiplier is used to carry out sum using BLAS
   Blob<Dtype> sum_multiplier_;
   /// scale is an intermediate Blob to hold temporary results.
   Blob<Dtype> scale_;
+  /// copy of input in order to cool it down   for calibration
+  Blob<Dtype> cooled_bottom_;
+
 };
 
 }  // namespace caffe

--- a/src/caffe/layers/softmax_layer.cpp
+++ b/src/caffe/layers/softmax_layer.cpp
@@ -21,6 +21,17 @@ void SoftmaxLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
   vector<int> scale_dims = bottom[0]->shape();
   scale_dims[softmax_axis_] = 1;
   scale_.Reshape(scale_dims);
+  if (this->layer_param_.has_scaling_temperature())
+    {
+      temperature_scaling_ = true;
+      temperature_ = this->layer_param_.scaling_temperature();
+      cooled_bottom_.ReshapeLike(*bottom[0]);
+    }
+  else
+    {
+      temperature_scaling_ = false;
+    }
+
 }
 
 template <typename Dtype>
@@ -31,6 +42,13 @@ void SoftmaxLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
   Dtype* scale_data = scale_.mutable_cpu_data();
   int channels = bottom[0]->shape(softmax_axis_);
   int dim = bottom[0]->count() / outer_num_;
+  if (temperature_scaling_)
+    {
+      Dtype * cooled_bottom_data = cooled_bottom_.mutable_cpu_data();
+      caffe_cpu_scale(bottom[0]->count(), (Dtype)1.0/temperature_, bottom_data, cooled_bottom_data);
+      bottom_data = cooled_bottom_data;
+    }
+
   caffe_copy(bottom[0]->count(), bottom_data, top_data);
   // We need to subtract the max to avoid numerical issues, compute the exp,
   // and then normalize.

--- a/src/caffe/layers/softmax_layer.cu
+++ b/src/caffe/layers/softmax_layer.cu
@@ -82,6 +82,7 @@ __global__ void kernel_channel_dot(const int num, const int channels,
   }
 }
 
+
 template <typename Dtype>
 void SoftmaxLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
@@ -90,6 +91,14 @@ void SoftmaxLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
   Dtype* scale_data = scale_.mutable_gpu_data();
   int count = bottom[0]->count();
   int channels = top[0]->shape(softmax_axis_);
+  if (temperature_scaling_)
+    {
+      Dtype * cooled_bottom_data;
+      cooled_bottom_data = cooled_bottom_.mutable_gpu_data();
+      caffe_gpu_scale(count, (Dtype)1.0/temperature_, bottom_data, cooled_bottom_data);
+      bottom_data = cooled_bottom_data;
+    }
+
   caffe_copy(count, bottom_data, top_data);
   // We need to subtract the max to avoid numerical issues, compute the exp,
   // and then normalize.

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -585,6 +585,9 @@ message LayerParameter {
   optional CtcLossParameter ctc_loss_param = 157;
   optional ContinuationIndicatorParameter continuation_indicator_param = 158;
   optional LabelsequenceAccuracyParameter labelsequence_accuracy_param = 159;
+  // scaling temperature is a factor for dividing logits before softmax
+  // when correctly set, improves confidence 
+  optional float scaling_temperature = 161 [default = 1.0];
 }
 
 // Message that stores parameters used to apply transformation


### PR DESCRIPTION
1 new float parameter in softmax layer that is used to divide logits before softmax  