### PR TITLE
Renamed CUDA_CHECK, CURAND_CHECK and CUBLAS_CHECK

### DIFF
--- a/include/caffe/syncedmem.hpp
+++ b/include/caffe/syncedmem.hpp
@@ -15,7 +15,7 @@ namespace caffe {
 inline void CaffeMallocHost(void** ptr, size_t size, bool* use_cuda) {
   /*#ifndef CPU_ONLY
   if (Caffe::mode() == Caffe::GPU) {
-    CUDA_CHECK(cudaMallocHost(ptr, size));
+    CAFFE1_CUDA_CHECK(cudaMallocHost(ptr, size));
     *use_cuda = true;
     return;
   }
@@ -29,7 +29,7 @@ inline void CaffeMallocHost(void** ptr, size_t size, bool* use_cuda) {
 inline void CaffeFreeHost(void* ptr, bool use_cuda) {
   /*#ifndef CPU_ONLY
   if (use_cuda) {
-    CUDA_CHECK(cudaFreeHost(ptr));
+    CAFFE1_CUDA_CHECK(cudaFreeHost(ptr));
     return;
   }
   #endif*/

--- a/include/caffe/util/device_alternate.hpp
+++ b/include/caffe/util/device_alternate.hpp
@@ -46,14 +46,14 @@ void classname<Dtype>::funcname##_##gpu(const vector<Blob<Dtype>*>& top, \
 //
 
 // CUDA: various checks for different function calls.
-#define CUDA_CHECK(condition) \
+#define CAFFE1_CUDA_CHECK(condition) \
   /* Code block avoids redefinition of cudaError_t error */ \
   do { \
     cudaError_t error = condition; \
     CHECK_EQ(error, cudaSuccess) << " " << cudaGetErrorString(error); \
   } while (0)
 
-#define CUBLAS_CHECK(condition) \
+#define CAFFE1_CUBLAS_CHECK(condition) \
   do { \
     cublasStatus_t status = condition; \
     CHECK_EQ(status, CUBLAS_STATUS_SUCCESS) << " " \
@@ -67,7 +67,7 @@ void classname<Dtype>::funcname##_##gpu(const vector<Blob<Dtype>*>& top, \
       << caffe::cusparseGetErrorString(status); \
   } while (0)
 
-#define CURAND_CHECK(condition) \
+#define CAFFE1_CURAND_CHECK(condition) \
   do { \
     curandStatus_t status = condition; \
     CHECK_EQ(status, CURAND_STATUS_SUCCESS) << " " \
@@ -81,7 +81,7 @@ void classname<Dtype>::funcname##_##gpu(const vector<Blob<Dtype>*>& top, \
        i += blockDim.x * gridDim.x)
 
 // CUDA: check for error after kernel execution and exit loudly if there is one.
-#define CUDA_POST_KERNEL_CHECK CUDA_CHECK(cudaPeekAtLastError())
+#define CUDA_POST_KERNEL_CHECK CAFFE1_CUDA_CHECK(cudaPeekAtLastError())
 
 namespace caffe {
 

--- a/include/caffe/util/math_functions.hpp
+++ b/include/caffe/util/math_functions.hpp
@@ -190,7 +190,7 @@ void caffe_gpu_set(const int N, const Dtype alpha, Dtype *X);
 
 inline void caffe_gpu_memset(const size_t N, const int alpha, void* X) {
 #ifndef CPU_ONLY
-  CUDA_CHECK(cudaMemset(X, alpha, N));  // NOLINT(caffe/alt_fn)
+  CAFFE1_CUDA_CHECK(cudaMemset(X, alpha, N));  // NOLINT(caffe/alt_fn)
 #else
   NO_GPU;
 #endif

--- a/src/caffe/common.cpp
+++ b/src/caffe/common.cpp
@@ -131,13 +131,13 @@ Caffe::Caffe()
 }
 
 Caffe::~Caffe() {
-  if (cublas_handle_) CUBLAS_CHECK(cublasDestroy(cublas_handle_));
+  if (cublas_handle_) CAFFE1_CUBLAS_CHECK(cublasDestroy(cublas_handle_));
   if (cusparse_handle_)
     CUSPARSE_CHECK(cusparseDestroy(cusparse_handle_));
   if (cusparse_mat_descr_)
     CUSPARSE_CHECK(cusparseDestroyMatDescr(cusparse_mat_descr_));
   if (curand_generator_) {
-    CURAND_CHECK(curandDestroyGenerator(curand_generator_));
+    CAFFE1_CURAND_CHECK(curandDestroyGenerator(curand_generator_));
   }
 }
 
@@ -145,9 +145,9 @@ void Caffe::set_random_seed(const unsigned int seed) {
   // Curand seed
   static bool g_curand_availability_logged = false;
   if (Get().curand_generator_) {
-    CURAND_CHECK(curandSetPseudoRandomGeneratorSeed(curand_generator(),
+    CAFFE1_CURAND_CHECK(curandSetPseudoRandomGeneratorSeed(curand_generator(),
         seed));
-    CURAND_CHECK(curandSetGeneratorOffset(curand_generator(), 0));
+    CAFFE1_CURAND_CHECK(curandSetGeneratorOffset(curand_generator(), 0));
   } else {
     if (!g_curand_availability_logged) {
         LOG(ERROR) <<
@@ -161,29 +161,29 @@ void Caffe::set_random_seed(const unsigned int seed) {
 
 void Caffe::SetDevice(const int device_id) {
   int current_device;
-  CUDA_CHECK(cudaGetDevice(&current_device));
+  CAFFE1_CUDA_CHECK(cudaGetDevice(&current_device));
   if (current_device == device_id) {
     return;
   }
   // The call to cudaSetDevice must come before any calls to Get, which
   // may perform initialization using the GPU.
-  CUDA_CHECK(cudaSetDevice(device_id));
-  if (Get().cublas_handle_) CUBLAS_CHECK(cublasDestroy(Get().cublas_handle_));
+  CAFFE1_CUDA_CHECK(cudaSetDevice(device_id));
+  if (Get().cublas_handle_) CAFFE1_CUBLAS_CHECK(cublasDestroy(Get().cublas_handle_));
   if (Get().cusparse_handle_)
     CUSPARSE_CHECK(cusparseDestroy(Get().cusparse_handle_));
   if (Get().cusparse_mat_descr_)
     CUSPARSE_CHECK(cusparseDestroyMatDescr(Get().cusparse_mat_descr_));
   if (Get().curand_generator_) {
-    CURAND_CHECK(curandDestroyGenerator(Get().curand_generator_));
+    CAFFE1_CURAND_CHECK(curandDestroyGenerator(Get().curand_generator_));
   }
-  CUBLAS_CHECK(cublasCreate(&Get().cublas_handle_));
+  CAFFE1_CUBLAS_CHECK(cublasCreate(&Get().cublas_handle_));
   CUSPARSE_CHECK(cusparseCreate(&Get().cusparse_handle_));
   CUSPARSE_CHECK(cusparseCreateMatDescr(&Get().cusparse_mat_descr_));
   cusparseSetMatType(Get().cusparse_mat_descr_, CUSPARSE_MATRIX_TYPE_GENERAL);
   cusparseSetMatIndexBase(Get().cusparse_mat_descr_, CUSPARSE_INDEX_BASE_ZERO);
-  CURAND_CHECK(curandCreateGenerator(&Get().curand_generator_,
+  CAFFE1_CURAND_CHECK(curandCreateGenerator(&Get().curand_generator_,
       CURAND_RNG_PSEUDO_DEFAULT));
-  CURAND_CHECK(curandSetPseudoRandomGeneratorSeed(Get().curand_generator_,
+  CAFFE1_CURAND_CHECK(curandSetPseudoRandomGeneratorSeed(Get().curand_generator_,
       cluster_seedgen()));
 }
 
@@ -194,7 +194,7 @@ void Caffe::DeviceQuery() {
     printf("No cuda device present.\n");
     return;
   }
-  CUDA_CHECK(cudaGetDeviceProperties(&prop, device));
+  CAFFE1_CUDA_CHECK(cudaGetDeviceProperties(&prop, device));
   LOG(INFO) << "Device id:                     " << device;
   LOG(INFO) << "Major revision number:         " << prop.major;
   LOG(INFO) << "Minor revision number:         " << prop.minor;
@@ -249,7 +249,7 @@ int Caffe::FindDevice(const int start_id) {
   // EXCLUSIVE_PROCESS or EXCLUSIVE_THREAD mode, if it succeeds, it also
   // claims the device due to the initialization of the context.
   int count = 0;
-  CUDA_CHECK(cudaGetDeviceCount(&count));
+  CAFFE1_CUDA_CHECK(cudaGetDeviceCount(&count));
   for (int i = start_id; i < count; i++) {
     if (CheckDevice(i)) return i;
   }

--- a/src/caffe/internal_thread.cpp
+++ b/src/caffe/internal_thread.cpp
@@ -23,7 +23,7 @@ void InternalThread::StartInternalThread() {
 
   int device = 0;
 #ifndef CPU_ONLY
-  CUDA_CHECK(cudaGetDevice(&device));
+  CAFFE1_CUDA_CHECK(cudaGetDevice(&device));
 #endif
   Caffe::Brew mode = Caffe::mode();
   int rand_seed = caffe_rng_rand();
@@ -42,7 +42,7 @@ void InternalThread::StartInternalThread() {
 void InternalThread::entry(int device, Caffe::Brew mode, int rand_seed,
     int solver_count, bool root_solver) {
 #ifndef CPU_ONLY
-  CUDA_CHECK(cudaSetDevice(device));
+  CAFFE1_CUDA_CHECK(cudaSetDevice(device));
 #endif
   Caffe::set_mode(mode);
   Caffe::set_random_seed(rand_seed);

--- a/src/caffe/layers/base_data_layer.cpp
+++ b/src/caffe/layers/base_data_layer.cpp
@@ -78,7 +78,7 @@ void BasePrefetchingDataLayer<Dtype>::InternalThreadEntry() {
 #ifndef CPU_ONLY
   cudaStream_t stream;
   if (Caffe::mode() == Caffe::GPU) {
-    CUDA_CHECK(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
+    CAFFE1_CUDA_CHECK(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
   }
 #endif
 
@@ -89,7 +89,7 @@ void BasePrefetchingDataLayer<Dtype>::InternalThreadEntry() {
 #ifndef CPU_ONLY
       if (Caffe::mode() == Caffe::GPU) {
         batch->data_.data().get()->async_gpu_push(stream);
-        CUDA_CHECK(cudaStreamSynchronize(stream));
+        CAFFE1_CUDA_CHECK(cudaStreamSynchronize(stream));
       }
 #endif
       prefetch_full_.push(batch);
@@ -99,7 +99,7 @@ void BasePrefetchingDataLayer<Dtype>::InternalThreadEntry() {
   }
 #ifndef CPU_ONLY
   if (Caffe::mode() == Caffe::GPU) {
-    CUDA_CHECK(cudaStreamDestroy(stream));
+    CAFFE1_CUDA_CHECK(cudaStreamDestroy(stream));
   }
 #endif
 }
@@ -176,7 +176,7 @@ void BasePrefetchingSparseDataLayer<Dtype>::InternalThreadEntry() {
 #ifndef CPU_ONLY
   cudaStream_t stream;
   if (Caffe::mode() == Caffe::GPU) {
-    CUDA_CHECK(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
+    CAFFE1_CUDA_CHECK(cudaStreamCreateWithFlags(&stream, cudaStreamNonBlocking));
   }
 #endif
 
@@ -187,7 +187,7 @@ void BasePrefetchingSparseDataLayer<Dtype>::InternalThreadEntry() {
 #ifndef CPU_ONLY
       if (Caffe::mode() == Caffe::GPU) {
         batch->data_.data().get()->async_gpu_push(stream);
-        CUDA_CHECK(cudaStreamSynchronize(stream));
+        CAFFE1_CUDA_CHECK(cudaStreamSynchronize(stream));
       }
 #endif
       prefetch_full_.push(batch);
@@ -197,7 +197,7 @@ void BasePrefetchingSparseDataLayer<Dtype>::InternalThreadEntry() {
   }
 #ifndef CPU_ONLY
   if (Caffe::mode() == Caffe::GPU) {
-    CUDA_CHECK(cudaStreamDestroy(stream));
+    CAFFE1_CUDA_CHECK(cudaStreamDestroy(stream));
   }
 #endif
 }

--- a/src/caffe/layers/base_data_layer.cu
+++ b/src/caffe/layers/base_data_layer.cu
@@ -22,7 +22,7 @@ void BasePrefetchingDataLayer<Dtype>::Forward_gpu(
   }
   // Ensure the copy is synchronous wrt the host, so that the next batch isn't
   // copied in meanwhile.
-  CUDA_CHECK(cudaStreamSynchronize(cudaStreamDefault));
+  CAFFE1_CUDA_CHECK(cudaStreamSynchronize(cudaStreamDefault));
   prefetch_free_.push(batch);
 }
 
@@ -57,7 +57,7 @@ void BasePrefetchingSparseDataLayer<Dtype>::Forward_gpu(
 
   // Ensure the copy is synchronous wrt the host, so that the next batch isn't
   // copied in meanwhile.
-  CUDA_CHECK(cudaStreamSynchronize(cudaStreamDefault));
+  CAFFE1_CUDA_CHECK(cudaStreamSynchronize(cudaStreamDefault));
   prefetch_free_.push(batch);
 }
 

--- a/src/caffe/layers/ctc_loss_layer.cu
+++ b/src/caffe/layers/ctc_loss_layer.cu
@@ -13,7 +13,7 @@ namespace caffe {
       cudaDeviceSynchronize();
       auto options = ctcOptions{};
       options.loc = CTC_GPU;
-      CUDA_CHECK(cudaStreamCreate(&(options.stream)));
+      CAFFE1_CUDA_CHECK(cudaStreamCreate(&(options.stream)));
       options.blank_label = blank_label_;
       int mini_batch = bottom[0]->shape()[1];
       int alphabet_size = alphabet_size_;
@@ -27,7 +27,7 @@ namespace caffe {
                       input_lengths_.data(), alphabet_size,
                       mini_batch, options, &size_bytes));
       void* workspace;
-      CUDA_CHECK(cudaMalloc(&workspace, size_bytes));
+      CAFFE1_CUDA_CHECK(cudaMalloc(&workspace, size_bytes));
       vector<Dtype> cost(mini_batch);
       CHECK_CTC_STATUS(compute_ctc_loss(activations, gradients,
                        flat_labels_.data(),
@@ -37,8 +37,8 @@ namespace caffe {
       Dtype loss = std::accumulate(cost.begin(), cost.end(), Dtype(0));
       top[0]->mutable_cpu_data()[0] = loss / mini_batch;
 
-      CUDA_CHECK(cudaFree(workspace));
-      CUDA_CHECK(cudaStreamDestroy(options.stream));
+      CAFFE1_CUDA_CHECK(cudaFree(workspace));
+      CAFFE1_CUDA_CHECK(cudaStreamDestroy(options.stream));
       CUDA_POST_KERNEL_CHECK;
   }
 

--- a/src/caffe/layers/cudnn_conv_layer.cpp
+++ b/src/caffe/layers/cudnn_conv_layer.cpp
@@ -49,7 +49,7 @@ void CuDNNConvolutionLayer<Dtype>::LayerSetUp(
   }
 
   for (int g = 0; g < this->group_ * CUDNN_STREAMS_PER_GROUP; g++) {
-    CUDA_CHECK(cudaStreamCreate(&stream_[g]));
+    CAFFE1_CUDA_CHECK(cudaStreamCreate(&stream_[g]));
     CUDNN_CHECK(cudnnCreate(&handle_[g]));
     CUDNN_CHECK(cudnnSetStream(handle_[g], stream_[g]));
     workspace[g] = NULL;

--- a/src/caffe/layers/cudnn_deconv_layer.cpp
+++ b/src/caffe/layers/cudnn_deconv_layer.cpp
@@ -49,7 +49,7 @@ void CuDNNDeconvolutionLayer<Dtype>::LayerSetUp(
   }
 
   for (int g = 0; g < this->group_ * CUDNN_STREAMS_PER_GROUP; g++) {
-    CUDA_CHECK(cudaStreamCreate(&stream_[g]));
+    CAFFE1_CUDA_CHECK(cudaStreamCreate(&stream_[g]));
     CUDNN_CHECK(cudnnCreate(&handle_[g]));
     CUDNN_CHECK(cudnnSetStream(handle_[g], stream_[g]));
     workspace[g] = NULL;

--- a/src/caffe/layers/cudnn_lcn_layer.cpp
+++ b/src/caffe/layers/cudnn_lcn_layer.cpp
@@ -46,8 +46,8 @@ void CuDNNLCNLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
     cudaFree(tempData2);
 
     // allocate new buffers
-    CUDA_CHECK(cudaMalloc(&tempData1, totalSizeInBytes));
-    CUDA_CHECK(cudaMalloc(&tempData2, totalSizeInBytes));
+    CAFFE1_CUDA_CHECK(cudaMalloc(&tempData1, totalSizeInBytes));
+    CAFFE1_CUDA_CHECK(cudaMalloc(&tempData2, totalSizeInBytes));
   }
 }
 

--- a/src/caffe/syncedmem.cpp
+++ b/src/caffe/syncedmem.cpp
@@ -14,9 +14,9 @@ SyncedMemory::~SyncedMemory() {
     int initial_device;
     cudaGetDevice(&initial_device);
     if (gpu_device_ != -1) {
-      CUDA_CHECK(cudaSetDevice(gpu_device_));
+      CAFFE1_CUDA_CHECK(cudaSetDevice(gpu_device_));
     }
-    CUDA_CHECK(cudaFree(gpu_ptr_));
+    CAFFE1_CUDA_CHECK(cudaFree(gpu_ptr_));
     cudaSetDevice(initial_device);
   }
 #endif  // CPU_ONLY
@@ -52,8 +52,8 @@ inline void SyncedMemory::to_gpu() {
 #ifndef CPU_ONLY
   switch (head_) {
   case UNINITIALIZED:
-    CUDA_CHECK(cudaGetDevice(&gpu_device_));
-    CUDA_CHECK(cudaMalloc(&gpu_ptr_, size_));
+    CAFFE1_CUDA_CHECK(cudaGetDevice(&gpu_device_));
+    CAFFE1_CUDA_CHECK(cudaMalloc(&gpu_ptr_, size_));
     own_gpu_data_ = true;
     caffe_gpu_memset(size_, 0, gpu_ptr_);
     head_ = HEAD_AT_GPU;
@@ -61,8 +61,8 @@ inline void SyncedMemory::to_gpu() {
     break;
   case HEAD_AT_CPU:
     if (gpu_ptr_ == NULL) {
-      CUDA_CHECK(cudaGetDevice(&gpu_device_));
-      CUDA_CHECK(cudaMalloc(&gpu_ptr_, size_));
+      CAFFE1_CUDA_CHECK(cudaGetDevice(&gpu_device_));
+      CAFFE1_CUDA_CHECK(cudaMalloc(&gpu_ptr_, size_));
       own_gpu_data_ = true;
     }
     caffe_gpu_memcpy(size_, cpu_ptr_, gpu_ptr_);
@@ -84,7 +84,7 @@ void SyncedMemory::clear_data() {
   }
 #ifndef CPU_ONLY
   if (gpu_ptr_ && own_gpu_data_) {
-    CUDA_CHECK(cudaFree(gpu_ptr_));
+    CAFFE1_CUDA_CHECK(cudaFree(gpu_ptr_));
     gpu_ptr_ = NULL;
   }
 #endif  // CPU_ONLY
@@ -132,9 +132,9 @@ const void* SyncedMemory::gpu_data() {
     int initial_device;
     cudaGetDevice(&initial_device);
     if (gpu_device_ != -1) {
-      CUDA_CHECK(cudaSetDevice(gpu_device_));
+      CAFFE1_CUDA_CHECK(cudaSetDevice(gpu_device_));
     }
-    CUDA_CHECK(cudaFree(gpu_ptr_));
+    CAFFE1_CUDA_CHECK(cudaFree(gpu_ptr_));
     cudaSetDevice(initial_device);
   }
   gpu_ptr_ = data;
@@ -156,9 +156,9 @@ const void* SyncedMemory::gpu_data() {
     int initial_device;
     cudaGetDevice(&initial_device);
     if (gpu_device_ != -1) {
-      CUDA_CHECK(cudaSetDevice(gpu_device_));
+      CAFFE1_CUDA_CHECK(cudaSetDevice(gpu_device_));
     }
-    CUDA_CHECK(cudaFree(gpu_ptr_));
+    CAFFE1_CUDA_CHECK(cudaFree(gpu_ptr_));
     cudaSetDevice(initial_device);
   }
   gpu_ptr_ = data;
@@ -177,7 +177,7 @@ const void* SyncedMemory::gpu_data() {
     size_ = size;
   }
   if (gpu_ptr_ && own_gpu_data_) {
-    CUDA_CHECK(cudaFree(gpu_ptr_));
+    CAFFE1_CUDA_CHECK(cudaFree(gpu_ptr_));
   }
 
   gpu_ptr_ = data;
@@ -209,12 +209,12 @@ void* SyncedMemory::mutable_gpu_data() {
 void SyncedMemory::async_gpu_push(const cudaStream_t& stream) {
   CHECK(head_ == HEAD_AT_CPU);
   if (gpu_ptr_ == NULL) {
-    CUDA_CHECK(cudaGetDevice(&gpu_device_));
-    CUDA_CHECK(cudaMalloc(&gpu_ptr_, size_));
+    CAFFE1_CUDA_CHECK(cudaGetDevice(&gpu_device_));
+    CAFFE1_CUDA_CHECK(cudaMalloc(&gpu_ptr_, size_));
     own_gpu_data_ = true;
   }
   const cudaMemcpyKind put = cudaMemcpyHostToDevice;
-  CUDA_CHECK(cudaMemcpyAsync(gpu_ptr_, cpu_ptr_, size_, put, stream));
+  CAFFE1_CUDA_CHECK(cudaMemcpyAsync(gpu_ptr_, cpu_ptr_, size_, put, stream));
   // Assume caller will synchronize on the stream before use
   head_ = SYNCED;
 }

--- a/src/caffe/test/test_common.cpp
+++ b/src/caffe/test/test_common.cpp
@@ -14,7 +14,7 @@ class CommonTest : public ::testing::Test {};
 
 TEST_F(CommonTest, TestCublasHandlerGPU) {
   int cuda_device_id;
-  CUDA_CHECK(cudaGetDevice(&cuda_device_id));
+  CAFFE1_CUDA_CHECK(cudaGetDevice(&cuda_device_id));
   EXPECT_TRUE(Caffe::cublas_handle());
 }
 
@@ -48,10 +48,10 @@ TEST_F(CommonTest, TestRandSeedGPU) {
   SyncedMemory data_a(10 * sizeof(unsigned int));
   SyncedMemory data_b(10 * sizeof(unsigned int));
   Caffe::set_random_seed(1701);
-  CURAND_CHECK(curandGenerate(Caffe::curand_generator(),
+  CAFFE1_CURAND_CHECK(curandGenerate(Caffe::curand_generator(),
         static_cast<unsigned int*>(data_a.mutable_gpu_data()), 10));
   Caffe::set_random_seed(1701);
-  CURAND_CHECK(curandGenerate(Caffe::curand_generator(),
+  CAFFE1_CURAND_CHECK(curandGenerate(Caffe::curand_generator(),
         static_cast<unsigned int*>(data_b.mutable_gpu_data()), 10));
   for (int i = 0; i < 10; ++i) {
     EXPECT_EQ(((const unsigned int*)(data_a.cpu_data()))[i],

--- a/src/caffe/test/test_gradient_based_solver.cpp
+++ b/src/caffe/test/test_gradient_based_solver.cpp
@@ -75,7 +75,7 @@ class GradientBasedSolverTest : public MultiDeviceTest<TypeParam> {
     int device_id = 0;
 #ifndef CPU_ONLY
     if (Caffe::mode() == Caffe::GPU) {
-      CUDA_CHECK(cudaGetDevice(&device_id));
+      CAFFE1_CUDA_CHECK(cudaGetDevice(&device_id));
     }
 #endif
     proto <<
@@ -460,7 +460,7 @@ class GradientBasedSolverTest : public MultiDeviceTest<TypeParam> {
     int available_devices = 1;
 #ifndef CPU_ONLY
     if (Caffe::mode() == Caffe::GPU) {
-      CUDA_CHECK(cudaGetDeviceCount(&available_devices));
+      CAFFE1_CUDA_CHECK(cudaGetDeviceCount(&available_devices));
     }
 #endif
     for (int devices = 1; devices <= available_devices; ++devices) {

--- a/src/caffe/util/benchmark.cpp
+++ b/src/caffe/util/benchmark.cpp
@@ -15,8 +15,8 @@ Timer::Timer()
 Timer::~Timer() {
   if (Caffe::mode() == Caffe::GPU) {
 #ifndef CPU_ONLY
-    CUDA_CHECK(cudaEventDestroy(start_gpu_));
-    CUDA_CHECK(cudaEventDestroy(stop_gpu_));
+    CAFFE1_CUDA_CHECK(cudaEventDestroy(start_gpu_));
+    CAFFE1_CUDA_CHECK(cudaEventDestroy(stop_gpu_));
 #else
     NO_GPU;
 #endif
@@ -27,7 +27,7 @@ void Timer::Start() {
   if (!running()) {
     if (Caffe::mode() == Caffe::GPU) {
 #ifndef CPU_ONLY
-      CUDA_CHECK(cudaEventRecord(start_gpu_, 0));
+      CAFFE1_CUDA_CHECK(cudaEventRecord(start_gpu_, 0));
 #else
       NO_GPU;
 #endif
@@ -43,7 +43,7 @@ void Timer::Stop() {
   if (running()) {
     if (Caffe::mode() == Caffe::GPU) {
 #ifndef CPU_ONLY
-      CUDA_CHECK(cudaEventRecord(stop_gpu_, 0));
+      CAFFE1_CUDA_CHECK(cudaEventRecord(stop_gpu_, 0));
 #else
       NO_GPU;
 #endif
@@ -65,8 +65,8 @@ float Timer::MicroSeconds() {
   }
   if (Caffe::mode() == Caffe::GPU) {
 #ifndef CPU_ONLY
-    CUDA_CHECK(cudaEventSynchronize(stop_gpu_));
-    CUDA_CHECK(cudaEventElapsedTime(&elapsed_milliseconds_, start_gpu_,
+    CAFFE1_CUDA_CHECK(cudaEventSynchronize(stop_gpu_));
+    CAFFE1_CUDA_CHECK(cudaEventElapsedTime(&elapsed_milliseconds_, start_gpu_,
                                     stop_gpu_));
     // Cuda only measure milliseconds
     elapsed_microseconds_ = elapsed_milliseconds_ * 1000;
@@ -89,8 +89,8 @@ float Timer::MilliSeconds() {
   }
   if (Caffe::mode() == Caffe::GPU) {
 #ifndef CPU_ONLY
-    CUDA_CHECK(cudaEventSynchronize(stop_gpu_));
-    CUDA_CHECK(cudaEventElapsedTime(&elapsed_milliseconds_, start_gpu_,
+    CAFFE1_CUDA_CHECK(cudaEventSynchronize(stop_gpu_));
+    CAFFE1_CUDA_CHECK(cudaEventElapsedTime(&elapsed_milliseconds_, start_gpu_,
                                     stop_gpu_));
 #else
       NO_GPU;
@@ -109,8 +109,8 @@ void Timer::Init() {
   if (!initted()) {
     if (Caffe::mode() == Caffe::GPU) {
 #ifndef CPU_ONLY
-      CUDA_CHECK(cudaEventCreate(&start_gpu_));
-      CUDA_CHECK(cudaEventCreate(&stop_gpu_));
+      CAFFE1_CUDA_CHECK(cudaEventCreate(&start_gpu_));
+      CAFFE1_CUDA_CHECK(cudaEventCreate(&stop_gpu_));
 #else
       NO_GPU;
 #endif

--- a/src/caffe/util/math_functions.cpp
+++ b/src/caffe/util/math_functions.cpp
@@ -218,7 +218,7 @@ void caffe_copy(const int N, const Dtype* X, Dtype* Y) {
     if (Caffe::mode() == Caffe::GPU) {
 #ifndef CPU_ONLY
       // NOLINT_NEXT_LINE(caffe/alt_fn)
-      CUDA_CHECK(cudaMemcpy(Y, X, sizeof(Dtype) * N, cudaMemcpyDefault));
+      CAFFE1_CUDA_CHECK(cudaMemcpy(Y, X, sizeof(Dtype) * N, cudaMemcpyDefault));
 #else
       NO_GPU;
 #endif

--- a/src/caffe/util/math_functions.cu
+++ b/src/caffe/util/math_functions.cu
@@ -24,7 +24,7 @@ void caffe_gpu_gemm<float>(const CBLAS_TRANSPOSE TransA,
       (TransA == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
   cublasOperation_t cuTransB =
       (TransB == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
-  CUBLAS_CHECK(cublasSgemm(Caffe::cublas_handle(), cuTransB, cuTransA,
+  CAFFE1_CUBLAS_CHECK(cublasSgemm(Caffe::cublas_handle(), cuTransB, cuTransA,
       N, M, K, &alpha, B, ldb, A, lda, &beta, C, N));
 }
 
@@ -40,7 +40,7 @@ void caffe_gpu_gemm<double>(const CBLAS_TRANSPOSE TransA,
       (TransA == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
   cublasOperation_t cuTransB =
       (TransB == CblasNoTrans) ? CUBLAS_OP_N : CUBLAS_OP_T;
-  CUBLAS_CHECK(cublasDgemm(Caffe::cublas_handle(), cuTransB, cuTransA,
+  CAFFE1_CUBLAS_CHECK(cublasDgemm(Caffe::cublas_handle(), cuTransB, cuTransA,
       N, M, K, &alpha, B, ldb, A, lda, &beta, C, N));
 }
 
@@ -50,7 +50,7 @@ void caffe_gpu_gemv<float>(const CBLAS_TRANSPOSE TransA, const int M,
     const float beta, float* y) {
   cublasOperation_t cuTransA =
       (TransA == CblasNoTrans) ? CUBLAS_OP_T : CUBLAS_OP_N;
-  CUBLAS_CHECK(cublasSgemv(Caffe::cublas_handle(), cuTransA, N, M, &alpha,
+  CAFFE1_CUBLAS_CHECK(cublasSgemv(Caffe::cublas_handle(), cuTransA, N, M, &alpha,
       A, N, x, 1, &beta, y, 1));
 }
 
@@ -60,36 +60,36 @@ void caffe_gpu_gemv<double>(const CBLAS_TRANSPOSE TransA, const int M,
     const double beta, double* y) {
   cublasOperation_t cuTransA =
       (TransA == CblasNoTrans) ? CUBLAS_OP_T : CUBLAS_OP_N;
-  CUBLAS_CHECK(cublasDgemv(Caffe::cublas_handle(), cuTransA, N, M, &alpha,
+  CAFFE1_CUBLAS_CHECK(cublasDgemv(Caffe::cublas_handle(), cuTransA, N, M, &alpha,
       A, N, x, 1, &beta, y, 1));
 }
 
 template <>
 void caffe_gpu_axpy<float>(const int N, const float alpha, const float* X,
     float* Y) {
-  CUBLAS_CHECK(cublasSaxpy(Caffe::cublas_handle(), N, &alpha, X, 1, Y, 1));
+  CAFFE1_CUBLAS_CHECK(cublasSaxpy(Caffe::cublas_handle(), N, &alpha, X, 1, Y, 1));
 }
 
 template <>
 void caffe_gpu_axpy<double>(const int N, const double alpha, const double* X,
     double* Y) {
-  CUBLAS_CHECK(cublasDaxpy(Caffe::cublas_handle(), N, &alpha, X, 1, Y, 1));
+  CAFFE1_CUBLAS_CHECK(cublasDaxpy(Caffe::cublas_handle(), N, &alpha, X, 1, Y, 1));
 }
 
 void caffe_gpu_memcpy(const size_t N, const void* X, void* Y) {
   if (X != Y) {
-    CUDA_CHECK(cudaMemcpy(Y, X, N, cudaMemcpyDefault));  // NOLINT(caffe/alt_fn)
+    CAFFE1_CUDA_CHECK(cudaMemcpy(Y, X, N, cudaMemcpyDefault));  // NOLINT(caffe/alt_fn)
   }
 }
 
 template <>
 void caffe_gpu_scal<float>(const int N, const float alpha, float *X) {
-  CUBLAS_CHECK(cublasSscal(Caffe::cublas_handle(), N, &alpha, X, 1));
+  CAFFE1_CUBLAS_CHECK(cublasSscal(Caffe::cublas_handle(), N, &alpha, X, 1));
 }
 
 template <>
 void caffe_gpu_scal<double>(const int N, const double alpha, double *X) {
-  CUBLAS_CHECK(cublasDscal(Caffe::cublas_handle(), N, &alpha, X, 1));
+  CAFFE1_CUBLAS_CHECK(cublasDscal(Caffe::cublas_handle(), N, &alpha, X, 1));
 }
 
 template <>
@@ -109,37 +109,37 @@ void caffe_gpu_axpby<double>(const int N, const double alpha, const double* X,
 template <>
 void caffe_gpu_dot<float>(const int n, const float* x, const float* y,
     float* out) {
-  CUBLAS_CHECK(cublasSdot(Caffe::cublas_handle(), n, x, 1, y, 1, out));
+  CAFFE1_CUBLAS_CHECK(cublasSdot(Caffe::cublas_handle(), n, x, 1, y, 1, out));
 }
 
 template <>
 void caffe_gpu_dot<double>(const int n, const double* x, const double* y,
     double * out) {
-  CUBLAS_CHECK(cublasDdot(Caffe::cublas_handle(), n, x, 1, y, 1, out));
+  CAFFE1_CUBLAS_CHECK(cublasDdot(Caffe::cublas_handle(), n, x, 1, y, 1, out));
 }
 
 template <>
 void caffe_gpu_asum<float>(const int n, const float* x, float* y) {
-  CUBLAS_CHECK(cublasSasum(Caffe::cublas_handle(), n, x, 1, y));
+  CAFFE1_CUBLAS_CHECK(cublasSasum(Caffe::cublas_handle(), n, x, 1, y));
 }
 
 template <>
 void caffe_gpu_asum<double>(const int n, const double* x, double* y) {
-  CUBLAS_CHECK(cublasDasum(Caffe::cublas_handle(), n, x, 1, y));
+  CAFFE1_CUBLAS_CHECK(cublasDasum(Caffe::cublas_handle(), n, x, 1, y));
 }
 
 template <>
 void caffe_gpu_scale<float>(const int n, const float alpha, const float *x,
                             float* y) {
-  CUBLAS_CHECK(cublasScopy(Caffe::cublas_handle(), n, x, 1, y, 1));
-  CUBLAS_CHECK(cublasSscal(Caffe::cublas_handle(), n, &alpha, y, 1));
+  CAFFE1_CUBLAS_CHECK(cublasScopy(Caffe::cublas_handle(), n, x, 1, y, 1));
+  CAFFE1_CUBLAS_CHECK(cublasSscal(Caffe::cublas_handle(), n, &alpha, y, 1));
 }
 
 template <>
 void caffe_gpu_scale<double>(const int n, const double alpha, const double *x,
                              double* y) {
-  CUBLAS_CHECK(cublasDcopy(Caffe::cublas_handle(), n, x, 1, y, 1));
-  CUBLAS_CHECK(cublasDscal(Caffe::cublas_handle(), n, &alpha, y, 1));
+  CAFFE1_CUBLAS_CHECK(cublasDcopy(Caffe::cublas_handle(), n, x, 1, y, 1));
+  CAFFE1_CUBLAS_CHECK(cublasDscal(Caffe::cublas_handle(), n, &alpha, y, 1));
 }
 
 template <typename Dtype>
@@ -152,7 +152,7 @@ __global__ void set_kernel(const int n, const Dtype alpha, Dtype* y) {
 template <typename Dtype>
 void caffe_gpu_set(const int N, const Dtype alpha, Dtype* Y) {
   if (alpha == 0) {
-    CUDA_CHECK(cudaMemset(Y, 0, sizeof(Dtype) * N));  // NOLINT(caffe/alt_fn)
+    CAFFE1_CUDA_CHECK(cudaMemset(Y, 0, sizeof(Dtype) * N));  // NOLINT(caffe/alt_fn)
     return;
   }
   // NOLINT_NEXT_LINE(whitespace/operators)
@@ -395,13 +395,13 @@ DEFINE_AND_INSTANTIATE_GPU_UNARY_FUNC(sign, y[index] = (Dtype(0) < x[index])
 DEFINE_AND_INSTANTIATE_GPU_UNARY_FUNC(sgnbit, y[index] = signbit(x[index]));
 
 void caffe_gpu_rng_uniform(const int n, unsigned int* r) {
-  CURAND_CHECK(curandGenerate(Caffe::curand_generator(), r, n));
+  CAFFE1_CURAND_CHECK(curandGenerate(Caffe::curand_generator(), r, n));
 }
 
 template <>
 void caffe_gpu_rng_uniform<float>(const int n, const float a, const float b,
                                   float* r) {
-  CURAND_CHECK(curandGenerateUniform(Caffe::curand_generator(), r, n));
+  CAFFE1_CURAND_CHECK(curandGenerateUniform(Caffe::curand_generator(), r, n));
   const float range = b - a;
   if (range != static_cast<float>(1)) {
     caffe_gpu_scal(n, range, r);
@@ -414,7 +414,7 @@ void caffe_gpu_rng_uniform<float>(const int n, const float a, const float b,
 template <>
 void caffe_gpu_rng_uniform<double>(const int n, const double a, const double b,
                                    double* r) {
-  CURAND_CHECK(curandGenerateUniformDouble(Caffe::curand_generator(), r, n));
+  CAFFE1_CURAND_CHECK(curandGenerateUniformDouble(Caffe::curand_generator(), r, n));
   const double range = b - a;
   if (range != static_cast<double>(1)) {
     caffe_gpu_scal(n, range, r);
@@ -427,14 +427,14 @@ void caffe_gpu_rng_uniform<double>(const int n, const double a, const double b,
 template <>
 void caffe_gpu_rng_gaussian(const int n, const float mu, const float sigma,
                             float* r) {
-  CURAND_CHECK(
+  CAFFE1_CURAND_CHECK(
       curandGenerateNormal(Caffe::curand_generator(), r, n, mu, sigma));
 }
 
 template <>
 void caffe_gpu_rng_gaussian(const int n, const double mu, const double sigma,
                             double* r) {
-  CURAND_CHECK(
+  CAFFE1_CURAND_CHECK(
       curandGenerateNormalDouble(Caffe::curand_generator(), r, n, mu, sigma));
 }
 
@@ -582,7 +582,7 @@ void caffe_gpu_csr_gemm<float>(const CBLAS_TRANSPOSE TransA,
   } else {
     // scale C by beta
     if (beta != 1.0) {
-      CUBLAS_CHECK(cublasSscal(Caffe::cublas_handle() , M * N, &beta, C, 1));
+      CAFFE1_CUBLAS_CHECK(cublasSscal(Caffe::cublas_handle() , M * N, &beta, C, 1));
     }
     const int average_nzz_per_row = nzz/K+1;
     dim3 grids((average_nzz_per_row+64-1)/64, N);
@@ -609,7 +609,7 @@ void caffe_gpu_csr_gemm<double>(const CBLAS_TRANSPOSE TransA,
   } else {
     // scale C by beta
     if (beta != 1.0) {
-      CUBLAS_CHECK(cublasDscal(Caffe::cublas_handle() , M * N, &beta, C, 1));
+      CAFFE1_CUBLAS_CHECK(cublasDscal(Caffe::cublas_handle() , M * N, &beta, C, 1));
     }
     const int average_nzz_per_row = nzz/K+1;
     dim3 grids((average_nzz_per_row+64-1)/64, N);
@@ -644,30 +644,30 @@ void caffe_gpu_csr_gemm<float>(const CBLAS_TRANSPOSE TransA,
     ldb_t = K;
     const float zero = 0.0;
     const float one = 1.0;
-    CUDA_CHECK(cudaMalloc((void**)&Bt, sizeof(float)*K*N));
-    CUBLAS_CHECK(cublasSgeam(Caffe::cublas_handle(), CUBLAS_OP_T, CUBLAS_OP_T, K, N, &one, B, ldb, &zero, B, ldb, Bt, ldb_t));
+    CAFFE1_CUDA_CHECK(cudaMalloc((void**)&Bt, sizeof(float)*K*N));
+    CAFFE1_CUBLAS_CHECK(cublasSgeam(Caffe::cublas_handle(), CUBLAS_OP_T, CUBLAS_OP_T, K, N, &one, B, ldb, &zero, B, ldb, Bt, ldb_t));
   }
 
   int msparse = (TransA == CblasNoTrans) ? M : K;
   int ksparse = (TransA == CblasNoTrans) ? K : M;
   if (orderC == CblasRowMajor){
     float* Ct;
-    CUDA_CHECK(cudaMalloc((void**)&Ct, sizeof(float)*M*N));
+    CAFFE1_CUDA_CHECK(cudaMalloc((void**)&Ct, sizeof(float)*M*N));
     const float zero = 0.0;
     const float one = 1.0;
     if (reuiqre_transpose_B){
       CUSPARSE_CHECK(cusparseScsrmm2(Caffe::cusparse_handle(), cuTransA, CUSPARSE_OPERATION_NON_TRANSPOSE, msparse, N, ksparse,nzz, &alpha, Caffe::cusparse_mat_descr(), A, ptr, indices, Bt,  ldb_t, &zero, Ct, M));
-      CUDA_CHECK(cudaFree(Bt));
+      CAFFE1_CUDA_CHECK(cudaFree(Bt));
     }else{
       CUSPARSE_CHECK(cusparseScsrmm2(Caffe::cusparse_handle(), cuTransA, cuTransB, msparse, N, ksparse,nzz, &alpha, Caffe::cusparse_mat_descr(), A, ptr, indices, B,  ldb, &zero, Ct, M));
     }
-    CUBLAS_CHECK(cublasSgeam(Caffe::cublas_handle(), CUBLAS_OP_T , CUBLAS_OP_N, N, M, &one, Ct, M, &beta, C, N, C, N));
-    CUDA_CHECK(cudaFree(Ct));
+    CAFFE1_CUBLAS_CHECK(cublasSgeam(Caffe::cublas_handle(), CUBLAS_OP_T , CUBLAS_OP_N, N, M, &one, Ct, M, &beta, C, N, C, N));
+    CAFFE1_CUDA_CHECK(cudaFree(Ct));
   }else{
     //this is the default of CUSPARSE by the Matrix B is by default rowmajor
     if (reuiqre_transpose_B){
       CUSPARSE_CHECK(cusparseScsrmm2(Caffe::cusparse_handle(), cuTransA, CUSPARSE_OPERATION_NON_TRANSPOSE, msparse, N, ksparse,nzz, &alpha, Caffe::cusparse_mat_descr(), A, ptr, indices, Bt,  ldb_t, &beta, C, M));
-      CUDA_CHECK(cudaFree(Bt));
+      CAFFE1_CUDA_CHECK(cudaFree(Bt));
     }else{
       CUSPARSE_CHECK(cusparseScsrmm2(Caffe::cusparse_handle(), cuTransA, cuTransB, msparse, N, ksparse,nzz, &alpha, Caffe::cusparse_mat_descr(), A, ptr, indices, B,  ldb, &beta, C, M));
     }
@@ -695,30 +695,30 @@ void caffe_gpu_csr_gemm<double>(const CBLAS_TRANSPOSE TransA,
     ldb_t = K;
     const double zero = 0.0;
     const double one = 1.0;
-    CUDA_CHECK(cudaMalloc((void**)&Bt, sizeof(double)*K*N));
-    CUBLAS_CHECK(cublasDgeam(Caffe::cublas_handle(), CUBLAS_OP_T, CUBLAS_OP_T, K, N, &one, B, ldb, &zero, B, ldb, Bt, ldb_t));
+    CAFFE1_CUDA_CHECK(cudaMalloc((void**)&Bt, sizeof(double)*K*N));
+    CAFFE1_CUBLAS_CHECK(cublasDgeam(Caffe::cublas_handle(), CUBLAS_OP_T, CUBLAS_OP_T, K, N, &one, B, ldb, &zero, B, ldb, Bt, ldb_t));
   }
 
   int msparse = (TransA == CblasNoTrans) ? M : K;
   int ksparse = (TransA == CblasNoTrans) ? K : M;
   if (orderC == CblasRowMajor){
     double* Ct;
-    CUDA_CHECK(cudaMalloc((void**)&Ct, sizeof(double)*M*N));
+    CAFFE1_CUDA_CHECK(cudaMalloc((void**)&Ct, sizeof(double)*M*N));
     const double zero = 0.0;
     const double one = 1.0;
     if (reuiqre_transpose_B){
       CUSPARSE_CHECK(cusparseDcsrmm2(Caffe::cusparse_handle(), cuTransA, CUSPARSE_OPERATION_NON_TRANSPOSE, msparse, N, ksparse,nzz, &alpha, Caffe::cusparse_mat_descr(), A, ptr, indices, Bt,  ldb_t, &zero, Ct, M));
-      CUDA_CHECK(cudaFree(Bt));
+      CAFFE1_CUDA_CHECK(cudaFree(Bt));
     }else{
       CUSPARSE_CHECK(cusparseDcsrmm2(Caffe::cusparse_handle(), cuTransA, cuTransB, msparse, N, ksparse,nzz, &alpha, Caffe::cusparse_mat_descr(), A, ptr, indices, B,  ldb, &zero, Ct, M));
     }
-    CUBLAS_CHECK(cublasDgeam(Caffe::cublas_handle(), CUBLAS_OP_T , CUBLAS_OP_N, N, M, &one, Ct, M, &beta, C, N, C, N));
-    CUDA_CHECK(cudaFree(Ct));
+    CAFFE1_CUBLAS_CHECK(cublasDgeam(Caffe::cublas_handle(), CUBLAS_OP_T , CUBLAS_OP_N, N, M, &one, Ct, M, &beta, C, N, C, N));
+    CAFFE1_CUDA_CHECK(cudaFree(Ct));
   }else{
     //this is the default of CUSPARSE by the Matrix B is by default rowmajor
     if (reuiqre_transpose_B){
       CUSPARSE_CHECK(cusparseDcsrmm2(Caffe::cusparse_handle(), cuTransA, CUSPARSE_OPERATION_NON_TRANSPOSE, msparse, N, ksparse,nzz, &alpha, Caffe::cusparse_mat_descr(), A, ptr, indices, Bt,  ldb_t, &beta, C, M));
-      CUDA_CHECK(cudaFree(Bt));
+      CAFFE1_CUDA_CHECK(cudaFree(Bt));
     }else{
       CUSPARSE_CHECK(cusparseDcsrmm2(Caffe::cusparse_handle(), cuTransA, cuTransB, msparse, N, ksparse,nzz, &alpha, Caffe::cusparse_mat_descr(), A, ptr, indices, B,  ldb, &beta, C, M));
     }

--- a/tools/caffe.cpp
+++ b/tools/caffe.cpp
@@ -90,7 +90,7 @@ static void get_gpus(vector<int>* gpus) {
   if (FLAGS_gpu == "all") {
     int count = 0;
 #ifndef CPU_ONLY
-    CUDA_CHECK(cudaGetDeviceCount(&count));
+    CAFFE1_CUDA_CHECK(cudaGetDeviceCount(&count));
 #else
     NO_GPU;
 #endif


### PR DESCRIPTION
They are defined in both caffe:
     include/caffe/util/device_alternate.hpp
and caffe2:
     caffe2/core/common_gpu.h

Renamed into CAFFE1_..._CHECK to prevent conflicts