### PR TITLE
Dice loss # 2

### DIFF
--- a/include/caffe/layers/dice_coef_loss_layer.hpp
+++ b/include/caffe/layers/dice_coef_loss_layer.hpp
@@ -50,9 +50,9 @@ class DiceCoefLossLayer : public LossLayer<Dtype> {
    * Unlike most loss layers, in the DiceCoefLossLayer we can backpropagate
    * to both inputs -- override to return true and always allow force_backward.
    */
-  virtual inline bool AllowForceBackward(const int bottom_index) const {
-    return true;
-  }
+  // virtual inline bool AllowForceBackward(const int bottom_index) const {
+  //   return true;
+  //  }
 
  protected:
   /// @copydoc DiceCoefLossLayer

--- a/src/caffe/layers/dice_coef_loss_layer.cpp
+++ b/src/caffe/layers/dice_coef_loss_layer.cpp
@@ -9,7 +9,7 @@ template <typename Dtype>
 void DiceCoefLossLayer<Dtype>::Reshape(
   const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
   LossLayer<Dtype>::Reshape(bottom, top);
-  CHECK_EQ(bottom[0]->count(1), bottom[1]->count(1))
+    CHECK_EQ(bottom[0]->count(1), bottom[1]->count(1))
       << "Inputs must have the same dimension.";
   const int batchsize = bottom[0]->num();
   const int dim = bottom[0]->count(1);
@@ -42,31 +42,46 @@ template <typename Dtype>
 void DiceCoefLossLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
 
-  // below is ok for no generalization == ignore_label == 0
-  // tmp_ <- b0 * b0
-  caffe_mul(bottom[0]->count(), bottom[0]->cpu_data(), bottom[0]->cpu_data(),
-            tmp_.mutable_cpu_data());
-  // result_tmp_ <- 1.*tmp_ * multiplier + 1*results_tmp_
-  caffe_cpu_gemv(CblasNoTrans, bottom[0]->num(), bottom[0]->count(1), Dtype(1.), tmp_.cpu_data(), 
-                    multiplier_.cpu_data(), Dtype(1.), result_tmp_.mutable_cpu_data());
-  // tmp_ <- b1 * b1
-  caffe_mul(bottom[1]->count(), bottom[1]->cpu_data(), bottom[1]->cpu_data(),
-              tmp_.mutable_cpu_data());
-  // result_tmp_ <- 1*tmp_*mult + 1*result_tmp
-  caffe_cpu_gemv(CblasNoTrans, bottom[1]->num(), bottom[1]->count(1), Dtype(1.), tmp_.cpu_data(), 
-                    multiplier_.cpu_data(), Dtype(1.), result_tmp_.mutable_cpu_data());
-  // tmp_ <- b0 * b1
-  caffe_mul(bottom[0]->count(), bottom[0]->cpu_data(), bottom[1]->cpu_data(), 
+
+
+  if (this->layer_param_.dice_coef_loss_param().squared())
+    {
+      // below is ok for no generalization == ignore_label == 0
+      // tmp_ <- b0 * b0
+      caffe_mul(bottom[0]->count(), bottom[0]->cpu_data(), bottom[0]->cpu_data(),
                 tmp_.mutable_cpu_data());
-  // result_ <- 1* tmp_ * multiplier + 1 *result_
-  caffe_cpu_gemv(CblasNoTrans, bottom[1]->num(), bottom[1]->count(1), Dtype(2.), tmp_.cpu_data(), 
-                    multiplier_.cpu_data(), Dtype(1.), result_.mutable_cpu_data());
-  // result_ <- result / result_tmp
-  caffe_div(bottom[0]->num(), result_.cpu_data(), result_tmp_.cpu_data(), result_.mutable_cpu_data());
-  
-  Dtype loss = Dtype(1) - caffe_cpu_asum(bottom[0]->num(), result_.cpu_data()) / bottom[0]->num();
-  top[0]->mutable_cpu_data()[0] = loss;
-}
+      // result_tmp_ <- 1.*tmp_ * multiplier + 1*results_tmp_
+      caffe_cpu_gemv(CblasNoTrans, bottom[0]->num(), bottom[0]->count(1), Dtype(1.), tmp_.cpu_data(),
+                     multiplier_.cpu_data(), Dtype(1.), result_tmp_.mutable_cpu_data());
+      // tmp_ <- b1 * b1
+      caffe_mul(bottom[1]->count(), bottom[1]->cpu_data(), bottom[1]->cpu_data(),
+                tmp_.mutable_cpu_data());
+      // result_tmp_ <- 1*tmp_*mult + 1*result_tmp
+      caffe_cpu_gemv(CblasNoTrans, bottom[1]->num(), bottom[1]->count(1), Dtype(1.), tmp_.cpu_data(),
+                     multiplier_.cpu_data(), Dtype(1.), result_tmp_.mutable_cpu_data());
+    }
+  else
+    {
+  // below unsquared version
+      caffe_cpu_gemv(CblasNoTrans, bottom[0]->num(), bottom[0]->count(1),
+                     Dtype(1.), bottom[0]->cpu_data(),
+                     multiplier_.cpu_data(), Dtype(1.), result_tmp_.mutable_cpu_data());
+      caffe_cpu_gemv(CblasNoTrans, bottom[1]->num(), bottom[1]->count(1),
+                     Dtype(1.),  bottom[1]->cpu_data(),
+                     multiplier_.cpu_data(), Dtype(1.), result_tmp_.mutable_cpu_data());
+    }
+
+      caffe_mul(bottom[0]->count(), bottom[0]->cpu_data(), bottom[1]->cpu_data(),
+                tmp_.mutable_cpu_data());
+      caffe_cpu_gemv(CblasNoTrans, bottom[1]->num(), bottom[1]->count(1), Dtype(2.), tmp_.cpu_data(),
+                     multiplier_.cpu_data(), Dtype(1.), result_.mutable_cpu_data());
+      caffe_div(bottom[0]->num(), result_.cpu_data(), result_tmp_.cpu_data(),
+                result_.mutable_cpu_data());
+
+
+      Dtype loss = Dtype(1) - caffe_cpu_asum(bottom[0]->num(), result_.cpu_data()) / bottom[0]->num();
+      top[0]->mutable_cpu_data()[0] = loss;
+    }
 
 template <typename Dtype>
 void DiceCoefLossLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
@@ -75,20 +90,46 @@ void DiceCoefLossLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
     if (propagate_down[i]) {
       const Dtype sign = Dtype(1.0);
       const int index = (i == 0) ? 1 : 0;
-      caffe_copy(bottom[i]->count(), bottom[i]->cpu_data(), bottom[i]->mutable_cpu_diff());
-      for (int j = 0; j < bottom[i]->num(); j++) {
-        //top[0]->cpu_diff()[0] is implicitely this loss weight, 1 for first top blob by default
-        const Dtype alpha = sign * top[0]->cpu_diff()[0] / result_tmp_.cpu_data()[j];
-        // LOG(INFO) << top[0]->cpu_diff()[0];
-        caffe_cpu_axpby(
-          bottom[i]->count(1),              // count
-          alpha*Dtype(-2),                  // alpha
-          bottom[index]->cpu_data()+j*bottom[i]->count(1),        // a
-          alpha*result_.cpu_data()[j]*Dtype(2),                      // beta
-          bottom[i]->mutable_cpu_diff()+j*bottom[i]->count(1)
-        );  // b
+      if (this->layer_param_.dice_coef_loss_param().squared())
+        {
+          caffe_copy(bottom[i]->count(), bottom[i]->cpu_data(), bottom[i]->mutable_cpu_diff());
+          for (int j = 0; j < bottom[i]->num(); j++) {
+            //top[0]->cpu_diff()[0] is implicitely this loss weight, 1 for first top blob by default
+            const Dtype alpha = sign * top[0]->cpu_diff()[0] / result_tmp_.cpu_data()[j];
+            // LOG(INFO) << top[0]->cpu_diff()[0];
+            caffe_cpu_axpby(
+                            bottom[i]->count(1),              // count
+                            alpha*Dtype(-2),                  // alpha
+                            bottom[index]->cpu_data()+j*bottom[i]->count(1),        // a
+                            alpha*result_.cpu_data()[j]*Dtype(2),                      // beta
+                            bottom[i]->mutable_cpu_diff()+j*bottom[i]->count(1)
+                            );  // b
         // GUILLO: CHECKED OK for NO GENERALIZATION
-      } 
+            //caffe_scal(bottom[i]->count(1), Dtype(bottom[i]->count(1)),
+            //         bottom[i]->mutable_cpu_diff()+j*bottom[i]->count(1));
+          }
+        }
+      else
+        {
+          caffe_set(bottom[i]->count(), Dtype(0.), bottom[i]->mutable_cpu_diff());
+          for (int j = 0; j < bottom[i]->num(); j++) {
+            //top[0]->cpu_diff()[0] is implicitely this loss weight, 1 for first top blob by default
+            const Dtype alpha = sign * top[0]->cpu_diff()[0] / result_tmp_.cpu_data()[j];
+            // LOG(INFO) << top[0]->cpu_diff()[0];
+            caffe_cpu_axpby(
+                            bottom[i]->count(1),              // count
+                            alpha*Dtype(-2),                  // alpha
+                            bottom[index]->cpu_data()+j*bottom[i]->count(1),        // a
+                            alpha*result_.cpu_data()[j],                      // beta
+                            bottom[i]->mutable_cpu_diff()+j*bottom[i]->count(1)
+                            );  // b
+           // GUILLO: CHECKED OK for NO GENERALIZATION
+
+          //
+            //            caffe_scal(bottom[i]->count(1), Dtype(bottom[i]->count(1)),
+            //           bottom[i]->mutable_cpu_diff()+j*bottom[i]->count(1));
+          }
+        }
     }
   }
 }

--- a/src/caffe/layers/dice_coef_loss_layer.cu
+++ b/src/caffe/layers/dice_coef_loss_layer.cu
@@ -10,27 +10,14 @@ void DiceCoefLossLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
   int count = bottom[0]->count();
 
-  if (this->layer_param_.dice_coef_loss_param().squared())
-    {
-      caffe_gpu_mul(count, bottom[0]->gpu_data(), bottom[0]->gpu_data(),
-                    tmp_.mutable_gpu_data());
-      caffe_gpu_gemv(CblasNoTrans, bottom[0]->num(), bottom[0]->count(1), Dtype(1.), tmp_.gpu_data(),
-                     multiplier_.gpu_data(), Dtype(1.), result_tmp_.mutable_gpu_data());
-      caffe_gpu_mul(count, bottom[1]->gpu_data(), bottom[1]->gpu_data(),
-                    tmp_.mutable_gpu_data());
-      caffe_gpu_gemv(CblasNoTrans, bottom[1]->num(), bottom[1]->count(1), Dtype(1.), tmp_.gpu_data(),
-                     multiplier_.gpu_data(), Dtype(1.), result_tmp_.mutable_gpu_data());
-    }
-  else
-    {
-      caffe_gpu_gemv(CblasNoTrans, bottom[0]->num(), bottom[0]->count(1),
-                     Dtype(1.), bottom[0]->gpu_data(),
-                     multiplier_.gpu_data(), Dtype(1.), result_tmp_.mutable_gpu_data());
-      caffe_gpu_gemv(CblasNoTrans, bottom[1]->num(), bottom[1]->count(1),
-                     Dtype(1.), bottom[1]->gpu_data(),
-                     multiplier_.gpu_data(), Dtype(1.), result_tmp_.mutable_gpu_data());
-
-    }
+  caffe_gpu_mul(count, bottom[0]->gpu_data(), bottom[0]->gpu_data(),
+                tmp_.mutable_gpu_data());
+  caffe_gpu_gemv(CblasNoTrans, bottom[0]->num(), bottom[0]->count(1), Dtype(1.), tmp_.gpu_data(),
+                 multiplier_.gpu_data(), Dtype(1.), result_tmp_.mutable_gpu_data());
+  caffe_gpu_mul(count, bottom[1]->gpu_data(), bottom[1]->gpu_data(),
+                tmp_.mutable_gpu_data());
+  caffe_gpu_gemv(CblasNoTrans, bottom[1]->num(), bottom[1]->count(1), Dtype(1.), tmp_.gpu_data(),
+                 multiplier_.gpu_data(), Dtype(1.), result_tmp_.mutable_gpu_data());
   caffe_gpu_mul(count, bottom[0]->gpu_data(), bottom[1]->gpu_data(),
                 tmp_.mutable_gpu_data());
   caffe_gpu_gemv(CblasNoTrans, bottom[1]->num(), bottom[1]->count(1), Dtype(2.), tmp_.gpu_data(),
@@ -48,23 +35,14 @@ void DiceCoefLossLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
 template <typename Dtype>
 __global__ void DiceCoefLossBackward(const int n, const Dtype* x,
                                      const Dtype* y, Dtype* out_diff, const Dtype sign,
-                                     const Dtype* loss, const Dtype* denominator, const int dim,
-                                     bool squared) {
+                                     const Dtype* loss, const Dtype* denominator, const int dim) {
   CUDA_KERNEL_LOOP(index, n)
     {
       const int i = index / dim;
       const Dtype alpha = Dtype(-2.) / denominator[i] * sign;
       Dtype beta;
-      if (squared)
-        {
-          beta = Dtype(2.) * loss[i] / denominator[i] * sign;
-          out_diff[index] = alpha * x[index] + beta * y[index];
-        }
-      else
-        {
-          beta =  loss[i] / denominator[i] * sign;
-          out_diff[index] = alpha * x[index] + beta;
-        }
+      beta = Dtype(2.) * loss[i] / denominator[i] * sign;
+      out_diff[index] = alpha * x[index] + beta * y[index];
    }
           // guillo: CHECKED ok for no generalization (same as cpu)
 }
@@ -72,28 +50,19 @@ __global__ void DiceCoefLossBackward(const int n, const Dtype* x,
 template <typename Dtype>
 void DiceCoefLossLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
     const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
-  bool squared = this->layer_param_.dice_coef_loss_param().squared();
 
   for (int i = 0; i < 2; ++i) {
-        if (propagate_down[i]) {
-        int count = bottom[i]->count();
-        const Dtype sign = Dtype(1.0)*top[0]->cpu_diff()[0];
-        const int index = (i == 0) ? 1 : 0;
-        DiceCoefLossBackward<Dtype><<<CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS>>>(
-        count, bottom[index]->gpu_data(), bottom[i]->gpu_data(), bottom[i]->mutable_gpu_diff(), 
-          sign, result_.gpu_data(), result_tmp_.gpu_data(), bottom[i]->count(1), squared);
-        CUDA_POST_KERNEL_CHECK;
-
-      }
-      }
-  /* std::cout << "propa0" << propagate_down[0]; */
-  /* std::cout << "\npropa1" << propagate_down[1]; */
-  /* std::cout << "\ndim" << bottom[0]->count(1); */
-  /* std::cout << "\ncount" << bottom[0]->count(0); */
-  /* std::cout << "\nsign: " << Dtype(1.0)*top[0]->cpu_diff()[0]; */
-  /* std::cout << "\nloss[0]: " << result_.cpu_data()[0]; */
-  /* std::cout << "\nloss[1]: " << result_.cpu_data()[1]; */
-  /* std::cout << "\ndenom: " << *result_tmp_.cpu_data(); */
+        if (propagate_down[i])
+          {
+          int count = bottom[i]->count();
+          const Dtype sign = Dtype(1.0)*top[0]->cpu_diff()[0];
+          const int index = (i == 0) ? 1 : 0;
+          DiceCoefLossBackward<Dtype><<<CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS>>>(
+          count, bottom[index]->gpu_data(), bottom[i]->gpu_data(), bottom[i]->mutable_gpu_diff(),
+            sign, result_.gpu_data(), result_tmp_.gpu_data(), bottom[i]->count(1));
+          CUDA_POST_KERNEL_CHECK;
+        }
+        }
 }
 
 INSTANTIATE_LAYER_GPU_FUNCS(DiceCoefLossLayer);

--- a/src/caffe/layers/dice_coef_loss_layer.cu
+++ b/src/caffe/layers/dice_coef_loss_layer.cu
@@ -9,22 +9,35 @@ template <typename Dtype>
 void DiceCoefLossLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
     const vector<Blob<Dtype>*>& top) {
   int count = bottom[0]->count();
-  
-  caffe_gpu_mul(count, bottom[0]->gpu_data(), bottom[0]->gpu_data(), 
+
+  if (this->layer_param_.dice_coef_loss_param().squared())
+    {
+      caffe_gpu_mul(count, bottom[0]->gpu_data(), bottom[0]->gpu_data(),
+                    tmp_.mutable_gpu_data());
+      caffe_gpu_gemv(CblasNoTrans, bottom[0]->num(), bottom[0]->count(1), Dtype(1.), tmp_.gpu_data(),
+                     multiplier_.gpu_data(), Dtype(1.), result_tmp_.mutable_gpu_data());
+      caffe_gpu_mul(count, bottom[1]->gpu_data(), bottom[1]->gpu_data(),
+                    tmp_.mutable_gpu_data());
+      caffe_gpu_gemv(CblasNoTrans, bottom[1]->num(), bottom[1]->count(1), Dtype(1.), tmp_.gpu_data(),
+                     multiplier_.gpu_data(), Dtype(1.), result_tmp_.mutable_gpu_data());
+    }
+  else
+    {
+      caffe_gpu_gemv(CblasNoTrans, bottom[0]->num(), bottom[0]->count(1),
+                     Dtype(1.), bottom[0]->gpu_data(),
+                     multiplier_.gpu_data(), Dtype(1.), result_tmp_.mutable_gpu_data());
+      caffe_gpu_gemv(CblasNoTrans, bottom[1]->num(), bottom[1]->count(1),
+                     Dtype(1.), bottom[1]->gpu_data(),
+                     multiplier_.gpu_data(), Dtype(1.), result_tmp_.mutable_gpu_data());
+
+    }
+  caffe_gpu_mul(count, bottom[0]->gpu_data(), bottom[1]->gpu_data(),
                 tmp_.mutable_gpu_data());
-  
-  caffe_gpu_gemv(CblasNoTrans, bottom[0]->num(), bottom[0]->count(1), Dtype(1.), tmp_.gpu_data(), 
-                    multiplier_.gpu_data(), Dtype(1.), result_tmp_.mutable_gpu_data());
-  caffe_gpu_mul(count, bottom[1]->gpu_data(), bottom[1]->gpu_data(), 
-                tmp_.mutable_gpu_data());
-  caffe_gpu_gemv(CblasNoTrans, bottom[1]->num(), bottom[1]->count(1), Dtype(1.), tmp_.gpu_data(), 
-                    multiplier_.gpu_data(), Dtype(1.), result_tmp_.mutable_gpu_data());
-  caffe_gpu_mul(count, bottom[0]->gpu_data(), bottom[1]->gpu_data(), 
-                tmp_.mutable_gpu_data());
-  caffe_gpu_gemv(CblasNoTrans, bottom[1]->num(), bottom[1]->count(1), Dtype(2.), tmp_.gpu_data(), 
-                    multiplier_.gpu_data(), Dtype(1.), result_.mutable_gpu_data());
-  caffe_gpu_div(bottom[0]->num(), result_.gpu_data(), result_tmp_.gpu_data(), 
+  caffe_gpu_gemv(CblasNoTrans, bottom[1]->num(), bottom[1]->count(1), Dtype(2.), tmp_.gpu_data(),
+                 multiplier_.gpu_data(), Dtype(1.), result_.mutable_gpu_data());
+  caffe_gpu_div(bottom[0]->num(), result_.gpu_data(), result_tmp_.gpu_data(),
                 result_.mutable_gpu_data());
+
   Dtype loss;
   caffe_gpu_asum(bottom[0]->num(), result_.gpu_data(), &loss);
   loss /= bottom[0]->num();
@@ -34,31 +47,53 @@ void DiceCoefLossLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
 
 template <typename Dtype>
 __global__ void DiceCoefLossBackward(const int n, const Dtype* x,
-    const Dtype* y, Dtype* out_diff, const Dtype sign,
-    const Dtype* loss, const Dtype* denominator, const int dim) {
-  CUDA_KERNEL_LOOP(index, n) {
-    const int i = index / dim;
-    const Dtype alpha = Dtype(-2.) / denominator[i] * sign;
-    const Dtype beta = Dtype(2.) * loss[i] / denominator[i] * sign;
-    out_diff[index] = alpha * x[index] + beta * y[index];
-  }
-  // guillo: CHECKED ok for no generalization (same as cpu)
+                                     const Dtype* y, Dtype* out_diff, const Dtype sign,
+                                     const Dtype* loss, const Dtype* denominator, const int dim,
+                                     bool squared) {
+  CUDA_KERNEL_LOOP(index, n)
+    {
+      const int i = index / dim;
+      const Dtype alpha = Dtype(-2.) / denominator[i] * sign;
+      Dtype beta;
+      if (squared)
+        {
+          beta = Dtype(2.) * loss[i] / denominator[i] * sign;
+          out_diff[index] = alpha * x[index] + beta * y[index];
+        }
+      else
+        {
+          beta =  loss[i] / denominator[i] * sign;
+          out_diff[index] = alpha * x[index] + beta;
+        }
+   }
+          // guillo: CHECKED ok for no generalization (same as cpu)
 }
 
 template <typename Dtype>
 void DiceCoefLossLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
     const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+  bool squared = this->layer_param_.dice_coef_loss_param().squared();
+
   for (int i = 0; i < 2; ++i) {
-    if (propagate_down[i]) {
-      int count = bottom[i]->count();
-      const Dtype sign = Dtype(1.0)*top[0]->cpu_diff()[0];
-      const int index = (i == 0) ? 1 : 0;
-      DiceCoefLossBackward<Dtype><<<CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS>>>(
+        if (propagate_down[i]) {
+        int count = bottom[i]->count();
+        const Dtype sign = Dtype(1.0)*top[0]->cpu_diff()[0];
+        const int index = (i == 0) ? 1 : 0;
+        DiceCoefLossBackward<Dtype><<<CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS>>>(
         count, bottom[index]->gpu_data(), bottom[i]->gpu_data(), bottom[i]->mutable_gpu_diff(), 
-        sign, result_.gpu_data(), result_tmp_.gpu_data(), bottom[i]->count(1));
-      CUDA_POST_KERNEL_CHECK;
-    }
-  }
+          sign, result_.gpu_data(), result_tmp_.gpu_data(), bottom[i]->count(1), squared);
+        CUDA_POST_KERNEL_CHECK;
+
+      }
+      }
+  /* std::cout << "propa0" << propagate_down[0]; */
+  /* std::cout << "\npropa1" << propagate_down[1]; */
+  /* std::cout << "\ndim" << bottom[0]->count(1); */
+  /* std::cout << "\ncount" << bottom[0]->count(0); */
+  /* std::cout << "\nsign: " << Dtype(1.0)*top[0]->cpu_diff()[0]; */
+  /* std::cout << "\nloss[0]: " << result_.cpu_data()[0]; */
+  /* std::cout << "\nloss[1]: " << result_.cpu_data()[1]; */
+  /* std::cout << "\ndenom: " << *result_tmp_.cpu_data(); */
 }
 
 INSTANTIATE_LAYER_GPU_FUNCS(DiceCoefLossLayer);

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -770,10 +770,7 @@ message DiceCoefLossParameter {
     BINARY = 1; // do no ignore any label, not yet implemented
     BINARY_WEIGHTED = 2; // generalized dice loss for two classes, not yet implemented
   }
-  optional GeneralizationMode generalization = 3 [default = NONE];
-
-  optional bool squared = 4 [default = false];
-  
+  optional GeneralizationMode generalization = 3 [default = NONE];  
 }
 
 // Message that stores parameters shared by loss layers

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -770,7 +770,9 @@ message DiceCoefLossParameter {
     BINARY = 1; // do no ignore any label, not yet implemented
     BINARY_WEIGHTED = 2; // generalized dice loss for two classes, not yet implemented
   }
-  optional GeneralizationMode generalization = 2 [default = NONE];
+  optional GeneralizationMode generalization = 3 [default = NONE];
+
+  optional bool squared = 4 [default = false];
   
 }
 


### PR DESCRIPTION
- add option for squared or unsquared version. Squared seems to smooth things but slows learning, some more testing required
- do not allow backward on labels (exactly, backwards only on bottom[0])
 (bottom[0] and bottom[1] are used symmetrically in formulas, previous version allowed caffe to choose what to backward)