### PR TITLE
Removing -O2 from caffe.pb.o flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -589,7 +589,7 @@ $(BUILD_DIR)/%.o: %.cpp $(PROTO_GEN_HEADER) | $(ALL_BUILD_DIRS)
 $(PROTO_BUILD_DIR)/%.pb.o: $(PROTO_BUILD_DIR)/%.pb.cc $(PROTO_GEN_HEADER) \
 		| $(PROTO_BUILD_DIR)
 	@ echo CXX $<
-	$(Q)$(CXX) $< $(CXXFLAGS) -c -o $@ 2> $@.$(WARNS_EXT) \
+	$(Q)$(CXX) $< $(CXXFLAGS:-O2=) -c -o $@ 2> $@.$(WARNS_EXT) \
 		|| (cat $@.$(WARNS_EXT); exit 1)
 	@ cat $@.$(WARNS_EXT)
 


### PR DESCRIPTION
Files that implement a protobuf virtual function may have a weird behavior
when both optimized and put inside a shared library
(depending on the version of the included headers)
So -O2 is removed

To see this behavior by yourself, here's a script that compile and execute a simple program in several ways:
- With and without -O2
- With and without a shared library
- With your system protobuf and with pytorch's protobuf

Works only if you have protobuf on your system and build pytorch

```
#!/bin/bash
PYTORCH_DIR="$HOME/pytorch"
TESTING_DIR="$HOME/tmp_test_zone"

mkdir -p $TESTING_DIR
OLD_PWD=$(pwd)
cd $TESTING_DIR

wget -q https://raw.githubusercontent.com/jolibrain/caffe/master/src/caffe/proto/caffe.proto
echo '
#include <iostream>
#include "caffe.pb.h"

int     main() {
        caffe::NetParameter net;
        net.set_name("valid");
        std::cout << net.DebugString() << std::endl;
        return 0;
}' > main.cc

# Arguments (booleans)
# Use pytorch protobuf
# Use O2 flag
# Use a shared library
function test() {
    if [ $1 -eq 1 ]
    then
        PROTO_TAG=CUSTOM
        PROTO_BIN=$PYTORCH_DIR/bin/protoc
        PROTO_INC=-I$PYTORCH_DIR/third_party/protobuf/src
        PROTO_LIB=-L$PYTORCH_DIR/lib
        LPATH=$PYTORCH_DIR/lib
    else
        PROTO_TAG=SYSTEM
        PROTO_BIN=protoc
        PROTO_INC=
        PROTO_LIB=
        LPATH=
    fi

    if [ $2 -eq 1 ]
    then
        O2_TAG="WITH -O2"
        O2_FLAG=-O2
    else
        O2_TAG=DISABLED
        O2_FLAG=
    fi
    if [ $3 -eq 1 ]
    then
        LINK_TAG="SHARED LIBRARY"
        LINK_FLAG="-L. -lmycaffe"
        if [ $1 -eq 1 ]
        then
            LPATH=$LPATH:.
        else
            LPATH=.
        fi
    else
        LINK_TAG="DIRECT .O FILE"
        LINK_FLAG=caffe.pb.o
    fi

    $PROTO_BIN  --cpp_out=. caffe.proto
    c++ -Wall -Wextra -c -o main.o main.cc $PROTO_INC
    c++ -Wall -Wextra -c -o caffe.pb.o -fPIC caffe.pb.cc $PROTO_INC $O2_FLAG

    if [ $3 -eq 1 ]
    then
    c++ -Wall -Wextra -shared -o libmycaffe.so caffe.pb.o $PROTO_LIB -lprotobuf
    fi

    c++ -Wall -Wextra -o test main.o $LINK_FLAG $PROTO_LIB -lprotobuf

    echo "--- Protobuf $PROTO_TAG --- Optimization $O2_TAG --- Link $LINK_TAG ---"
    LD_LIBRARY_PATH=$LPATH ./test
}

for pb in 0 1
do
    for O2 in 0 1
    do
        for so in 0 1
        do
            test $pb $O2 $so
        done
    done
done

rm caffe.pb.cc caffe.pb.h caffe.pb.o caffe.proto libmycaffe.so main.cc main.o test

cd $OLD_PWD

rmdir $TESTING_DIR
```