### PR TITLE
debug noise free output data layer

### DIFF
--- a/include/caffe/data_transformer.hpp
+++ b/include/caffe/data_transformer.hpp
@@ -188,7 +188,8 @@ class DataTransformer {
    */
   void Transform(const cv::Mat& cv_img, Blob<Dtype>* transformed_blob,
                  NormalizedBBox* crop_bbox, bool* do_mirror,
-		 bool preserve_pixel_vals = false, bool preserve_annotations = false);
+                 bool preserve_pixel_vals = false, bool preserve_annotations = false,
+                 bool use_previous_mirror_value = false);
   void Transform(const cv::Mat& cv_img, Blob<Dtype>* transformed_blob,
 		 bool preserve_pixel_vals = false, bool preserve_annotations = false);
 
@@ -258,6 +259,17 @@ class DataTransformer {
    */
   vector<int> InferBlobShape(const cv::Mat& cv_img);
 
+  /**
+   * @brief Applies the transformation defined in the data layer's
+   * transform_param block to the data and return transform information.
+   */
+  void Transform(const Datum& datum, Blob<Dtype>* transformed_blob,
+                 NormalizedBBox* crop_bbox, bool* do_mirror,
+                 const bool preserve_pixel_vals = false,
+                 const bool preserve_annotations = false,
+                 const bool use_previous_mirror_value = false);
+
+
  protected:
    /**
    * @brief Generates a random integer from Uniform({0, 1, ..., n-1}).
@@ -273,16 +285,6 @@ class DataTransformer {
   void Transform(const Datum& datum, Dtype* transformed_data,
                  NormalizedBBox* crop_bbox, bool* do_mirror);
   void Transform(const Datum& datum, Dtype* transformed_data);
-
-  /**
-   * @brief Applies the transformation defined in the data layer's
-   * transform_param block to the data and return transform information.
-   */
-  void Transform(const Datum& datum, Blob<Dtype>* transformed_blob,
-                 NormalizedBBox* crop_bbox, bool* do_mirror,
-		 const bool preserve_pixel_vals = false,
-		 const bool preserve_annotations = false);
-
 
 
   // Tranformation parameters

--- a/src/caffe/data_transformer.cpp
+++ b/src/caffe/data_transformer.cpp
@@ -156,7 +156,8 @@ void DataTransformer<Dtype>::Transform(const Datum& datum,
                                        NormalizedBBox* crop_bbox,
                                        bool* do_mirror,
 				       const bool preserve_pixel_vals,
-				       const bool preserve_annotations) {
+                                       const bool preserve_annotations,
+                                       const bool use_previous_mirror_value) {
   // If datum is encoded, decoded and transform the cv::image.
   if (datum.encoded()) {
 #ifdef USE_OPENCV
@@ -171,7 +172,7 @@ void DataTransformer<Dtype>::Transform(const Datum& datum,
     }
     // Transform the cv::image into blob.
     return Transform(cv_img, transformed_blob, crop_bbox, do_mirror,
-		     preserve_pixel_vals, preserve_annotations);
+                     preserve_pixel_vals, preserve_annotations, use_previous_mirror_value);
 #else
     LOG(ERROR) << "Encoded datum requires OpenCV; compile with USE_OPENCV.";
     LOG(FATAL) << "fatal error";
@@ -702,7 +703,8 @@ void DataTransformer<Dtype>::Transform(const cv::Mat& cv_img,
                                        NormalizedBBox* crop_bbox,
                                        bool* do_mirror,
                                        bool preserve_pixel_vals,
-				       bool preserve_annotations) {
+                                       bool preserve_annotations,
+                                       bool use_previous_mirror_value) {
   // Check dimensions.
   const int img_channels = cv_img.channels();
   const int channels = transformed_blob->channels();
@@ -717,7 +719,8 @@ void DataTransformer<Dtype>::Transform(const cv::Mat& cv_img,
 
   const int crop_size = param_.crop_size();
   const Dtype scale = param_.scale();
-  *do_mirror = param_.mirror() && Rand(2);
+  if (!use_previous_mirror_value)
+    *do_mirror = param_.mirror() && Rand(2);
   const bool has_mean_file = param_.has_mean_file();
   const bool has_mean_values = mean_values_.size() > 0;
 

--- a/src/caffe/layers/data_layer.cpp
+++ b/src/caffe/layers/data_layer.cpp
@@ -187,12 +187,17 @@ void DataLayer<Dtype>::load_batch_and_untransformed_batch(Batch<Dtype>* batch, B
     // Apply data transformations (mirror, scale, crop...)
     int offset = batch->data_.offset(item_id);
     this->transformed_data_.set_cpu_data(top_data + offset);
-    this->data_transformer_->Transform(datum, &(this->transformed_data_));
+    //    this->data_transformer_->Transform(datum, &(this->transformed_data_));
+    NormalizedBBox crop_bbox;
+    bool do_mirror;
+    this->data_transformer_->Transform(datum, &(this->transformed_data_),&crop_bbox, &do_mirror,
+                                       false, false);
+
     if (this->untransformed_top_)
       {
         this->untransformed_data_.set_cpu_data(untransformed_top_data + offset);
         // apply mirror bu not noise neither distort neither rotate
-        this->data_transformer_->Transform(datum, &(this->untransformed_data_),true, false);
+        this->data_transformer_->Transform(datum, &(this->untransformed_data_),&crop_bbox, &do_mirror, true, false, true);
       }
     // Copy label.
     if (this->output_labels_) {


### PR DESCRIPTION
use same do_mirror value for transformed and untransformed tops, previously they were independent
(meaning that it was possible to have an mirrored untransformed_top with an unmirrored top_data, and vice_versa)