### PR TITLE
debug smooth l1 loss

### DIFF
--- a/src/caffe/layers/smooth_l1_loss_layer.cpp
+++ b/src/caffe/layers/smooth_l1_loss_layer.cpp
@@ -7,6 +7,7 @@ namespace caffe {
 template <typename Dtype>
 void SmoothL1LossLayer<Dtype>::LayerSetUp(
   const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  LossLayer<Dtype>::LayerSetUp(bottom, top);
   SmoothL1LossParameter loss_param = this->layer_param_.smooth_l1_loss_param();
   sigma2_ = loss_param.sigma() * loss_param.sigma();
   has_weights_ = (bottom.size() >= 3);
@@ -66,7 +67,7 @@ void SmoothL1LossLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
   for (int i = 0; i < count; ++i) {
     Dtype val = diff_data[i];
     Dtype abs_val = fabs(val);
-    if (abs_val < 1.) {
+    if (abs_val < 1. / sigma2_) {
       error_data[i] = 0.5 * val * val * sigma2_;
     } else {
       error_data[i] = abs_val - 0.5 / sigma2_;

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -1834,6 +1834,8 @@ message SmoothL1LossParameter {
   //   0.5 * (sigma * x) ** 2    -- if x < 1.0 / sigma / sigma
   //   |x| - 0.5 / sigma / sigma -- otherwise
   optional float sigma = 1 [default = 1];
+  // for timeseries case, we use this loss as default
+  //default is set to 100, giving almost L1 loss (until |diff|<100*100)
 }
 
 // Message that stores parameters used by SoftmaxLayer, SoftmaxWithLossLayer


### PR DESCRIPTION
-  correct init in order to output loss value (was outputting 0 because output not registered as a loss)
- stick to definition of use of sigma in case of parametrized l1 loss (see https://mohitjainweb.files.wordpress.com/2018/03/smoothl1loss.pdf )