### PR TITLE
Soft multilabel fix

### DIFF
--- a/include/caffe/layers/multilabel_sigmoid_loss_layer.hpp
+++ b/include/caffe/layers/multilabel_sigmoid_loss_layer.hpp
@@ -21,7 +21,8 @@ class MultiLabelSigmoidLossLayer : public LossLayer<Dtype> {
   explicit MultiLabelSigmoidLossLayer(const LayerParameter& param)
       : LossLayer<Dtype>(param), diff_(),
           sigmoid_layer_(new SigmoidLayer<Dtype>(param)),
-          sigmoid_output_(new Blob<Dtype>()) {}
+          sigmoid_output_(new Blob<Dtype>()) {
+  }
   virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
   /*virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
@@ -60,6 +61,7 @@ class MultiLabelSigmoidLossLayer : public LossLayer<Dtype> {
   vector<Blob<Dtype>*> sigmoid_bottom_vec_;
   /// top vector holder to call the underlying SigmoidLayer::Forward
   vector<Blob<Dtype>*> sigmoid_top_vec_;
+
 
 };
 

--- a/include/caffe/layers/multilabel_sigmoid_loss_layer.hpp
+++ b/include/caffe/layers/multilabel_sigmoid_loss_layer.hpp
@@ -21,8 +21,7 @@ class MultiLabelSigmoidLossLayer : public LossLayer<Dtype> {
   explicit MultiLabelSigmoidLossLayer(const LayerParameter& param)
       : LossLayer<Dtype>(param), diff_(),
           sigmoid_layer_(new SigmoidLayer<Dtype>(param)),
-          sigmoid_output_(new Blob<Dtype>()) {
-  }
+          sigmoid_output_(new Blob<Dtype>()) {}
   virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
   /*virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
@@ -61,7 +60,6 @@ class MultiLabelSigmoidLossLayer : public LossLayer<Dtype> {
   vector<Blob<Dtype>*> sigmoid_bottom_vec_;
   /// top vector holder to call the underlying SigmoidLayer::Forward
   vector<Blob<Dtype>*> sigmoid_top_vec_;
-
 
 };
 

--- a/src/caffe/layers/multi_label_sigmoid_loss_layer.cpp
+++ b/src/caffe/layers/multi_label_sigmoid_loss_layer.cpp
@@ -108,14 +108,14 @@ void MultiLabelSigmoidLossLayer<Dtype>::Backward_cpu(
     Dtype* bottom_diff = bottom[0]->mutable_cpu_diff();
     int valid_count = 0;
     for (int i = 0; i < count; ++i) {
-      if (target[i]<0 || target[i] > 1)
-        {
-          bottom_diff[i] = 0;
-        }
-      else
+      if (target[i]>=0 && target[i] <= 1)
         {
           bottom_diff[i] = sigmoid_output_data[i] - target[i];
           valid_count++;
+        }
+      else
+        {
+          bottom_diff[i] = 0;
         }
     }
     // Scale down gradient

--- a/src/caffe/layers/multi_label_sigmoid_loss_layer.cpp
+++ b/src/caffe/layers/multi_label_sigmoid_loss_layer.cpp
@@ -74,8 +74,8 @@ void MultiLabelSigmoidLossLayer<Dtype>::Forward_cpu(
   Dtype loss = 0;
   int valid_count = 0;
   for (int i = 0; i < count; ++i) {
-    if (target[i] >= 0) {
-    // Update the loss only if target[i] is not -1
+    if (target[i] >=0 && target[i] <=1) {
+    // Update the loss only if target[i] is within [0,1]
       loss -= input_data[i] * (target[i] - (input_data[i] >= 0)) -
         log(1 + exp(input_data[i] - 2 * input_data[i] * (input_data[i] >= 0)));
       ++valid_count;
@@ -108,12 +108,15 @@ void MultiLabelSigmoidLossLayer<Dtype>::Backward_cpu(
     Dtype* bottom_diff = bottom[0]->mutable_cpu_diff();
     int valid_count = 0;
     for (int i = 0; i < count; ++i) {
-      if (target[i] >= 0) {
-        bottom_diff[i] = sigmoid_output_data[i] - target[i];
-        valid_count++;
-      } else {
-        bottom_diff[i] = 0;
-      }
+      if (target[i]<0 || target[i] > 1)
+        {
+          bottom_diff[i] = 0;
+        }
+      else
+        {
+          bottom_diff[i] = sigmoid_output_data[i] - target[i];
+          valid_count++;
+        }
     }
     // Scale down gradient
     const Dtype loss_weight = top[0]->cpu_diff()[0];

--- a/src/caffe/layers/multi_label_sigmoid_loss_layer.cu
+++ b/src/caffe/layers/multi_label_sigmoid_loss_layer.cu
@@ -9,22 +9,22 @@ namespace caffe {
 template <typename Dtype>
 __global__ void MultiLabelSigmoidLossForwardGPU(const int nthreads,
           const Dtype* input_data, const Dtype* target, Dtype* loss,
-                                                Dtype* counts) {
+          Dtype* counts) {
   CUDA_KERNEL_LOOP(i, nthreads) {
     //    const Dtype target_value = static_cast<Dtype>(target[i]);
-    if (target[i] < 0 || target[i] > 1)
-      {
-        counts[i] = 0;
-        loss[i] = 0;
-      }
-    else
+    if (target[i] >= 0 && target[i] <= 1)
       {
         loss[i] = input_data[i] * (target[i] - (input_data[i] >= 0)) -
           log(1 + exp(input_data[i] - 2 * input_data[i] *
                       (input_data[i] >= 0)));
         counts[i] = 1;
       }
-    }
+    elsge
+      {
+        counts[i] = 0;
+        loss[i] = 0;
+      }
+  }
  }
 
 
@@ -66,7 +66,7 @@ void MultiLabelSigmoidLossLayer<Dtype>::Forward_gpu(
   // NOLINT_NEXT_LINE(whitespace/operators)
   MultiLabelSigmoidLossForwardGPU<Dtype><<<CAFFE_GET_BLOCKS(count),
       CAFFE_CUDA_NUM_THREADS>>>(count, input_data, target, loss_data,
-                                count_data);
+      count_data);
   caffe_gpu_asum(count, count_data, &valid_count);
   Dtype loss;
   caffe_gpu_asum(count, loss_data, &loss);

--- a/src/caffe/layers/multi_label_sigmoid_loss_layer.cu
+++ b/src/caffe/layers/multi_label_sigmoid_loss_layer.cu
@@ -19,7 +19,7 @@ __global__ void MultiLabelSigmoidLossForwardGPU(const int nthreads,
                       (input_data[i] >= 0)));
         counts[i] = 1;
       }
-    elsge
+    else
       {
         counts[i] = 0;
         loss[i] = 0;


### PR DESCRIPTION
previously, all target data < 0 was discarded as a potential ignore_value / ignore_label (ignore_value was supposed to be -1), now we also discard every value >1 in order to be consistent