### PR TITLE
scale displayed loss so that we have an idea of relative error

### DIFF
--- a/include/caffe/layers/smooth_l1_loss_layer.hpp
+++ b/include/caffe/layers/smooth_l1_loss_layer.hpp
@@ -58,6 +58,7 @@ class SmoothL1LossLayer : public LossLayer<Dtype> {
   Blob<Dtype> ones_;
   bool has_weights_;
   Dtype sigma2_;
+  bool norm_loss_by_count_;
 };
 
 }  // namespace caffe

--- a/src/caffe/layers/smooth_l1_loss_layer.cpp
+++ b/src/caffe/layers/smooth_l1_loss_layer.cpp
@@ -101,7 +101,11 @@ void SmoothL1LossLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
   for (int i = 0; i < 2; ++i) {
     if (propagate_down[i]) {
       const Dtype sign = (i == 0) ? 1 : -1;
-      const Dtype alpha = sign * top[0]->cpu_diff()[0] / bottom[i]->num();
+      Dtype alpha;
+      if (norm_loss_by_count_)
+        alpha = sign * top[0]->cpu_diff()[0] / bottom[i]->count();
+      else
+        alpha = sign * top[0]->cpu_diff()[0] / bottom[i]->num();
       caffe_cpu_axpby(
 		      bottom[i]->count(),               // count
 		      alpha,                            // alpha

--- a/src/caffe/layers/smooth_l1_loss_layer.cpp
+++ b/src/caffe/layers/smooth_l1_loss_layer.cpp
@@ -10,7 +10,7 @@ void SmoothL1LossLayer<Dtype>::LayerSetUp(
   LossLayer<Dtype>::LayerSetUp(bottom, top);
   SmoothL1LossParameter loss_param = this->layer_param_.smooth_l1_loss_param();
   sigma2_ = loss_param.sigma() * loss_param.sigma();
-  norm_loss_by_count_ = (loss_param.norm_mode() == SmoothL1LossParameter::COUNT);
+  norm_loss_by_count_ = (this->layer_param_.loss_param().normalization() == LossParameter::FULL);
   has_weights_ = (bottom.size() >= 3);
   if (has_weights_) {
     CHECK_EQ(bottom.size(), 4) << "If weights are used, must specify both "

--- a/src/caffe/layers/smooth_l1_loss_layer.cu
+++ b/src/caffe/layers/smooth_l1_loss_layer.cu
@@ -54,7 +54,11 @@ void SmoothL1LossLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
 
   Dtype loss;
   caffe_gpu_dot(count, ones_.gpu_data(), errors_.gpu_data(), &loss);
-  top[0]->mutable_cpu_data()[0] = loss / bottom[0]->num();
+  if (norm_loss_by_count_)
+    top[0]->mutable_cpu_data()[0] = loss / bottom[0]->count();
+  else
+    top[0]->mutable_cpu_data()[0] = loss / bottom[0]->num();
+
 }
 
 template <typename Dtype>

--- a/src/caffe/layers/smooth_l1_loss_layer.cu
+++ b/src/caffe/layers/smooth_l1_loss_layer.cu
@@ -90,7 +90,11 @@ void SmoothL1LossLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
   for (int i = 0; i < 2; ++i) {
     if (propagate_down[i]) {
       const Dtype sign = (i == 0) ? 1 : -1;
-      const Dtype alpha = sign * top[0]->cpu_diff()[0] / bottom[i]->num();
+      Dtype alpha;
+      if (norm_loss_by_count_)
+        alpha = sign * top[0]->cpu_diff()[0] / bottom[i]->count();
+      else
+        alpha = sign * top[0]->cpu_diff()[0] / bottom[i]->num();
       caffe_gpu_axpby(
           count,                           // count
           alpha,                           // alpha

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -1834,15 +1834,6 @@ message SmoothL1LossParameter {
   //   0.5 * (sigma * x) ** 2    -- if x < 1.0 / sigma / sigma
   //   |x| - 0.5 / sigma / sigma -- otherwise
   optional float sigma = 1 [default = 1];
-  // if normmode = count, divide printed loss by total number of atomic element and not only
-  // by batch size
-  // giving an average error per float value and not the average over the sum over the vector
-  enum NormMode {
-    DEFAULT = 0;
-    COUNT = 1;
-  }
-  optional NormMode norm_mode = 2 [default = DEFAULT]; 
-  // for timeseries case, we use this loss as default
   //default is set to 100, giving almost L1 loss (until |diff|<100*100)
 }
 

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -1834,6 +1834,7 @@ message SmoothL1LossParameter {
   //   0.5 * (sigma * x) ** 2    -- if x < 1.0 / sigma / sigma
   //   |x| - 0.5 / sigma / sigma -- otherwise
   optional float sigma = 1 [default = 1];
+  // for timeseries case, we use this loss as default
   //default is set to 100, giving almost L1 loss (until |diff|<100*100)
 }
 

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -1834,6 +1834,14 @@ message SmoothL1LossParameter {
   //   0.5 * (sigma * x) ** 2    -- if x < 1.0 / sigma / sigma
   //   |x| - 0.5 / sigma / sigma -- otherwise
   optional float sigma = 1 [default = 1];
+  // if normmode = count, divide printed loss by total number of atomic element and not only
+  // by batch size
+  // giving an average error per float value and not the average over the sum over the vector
+  enum NormMode {
+    DEFAULT = 0;
+    COUNT = 1;
+  }
+  optional NormMode norm_mode = 2 [default = DEFAULT]; 
   // for timeseries case, we use this loss as default
   //default is set to 100, giving almost L1 loss (until |diff|<100*100)
 }


### PR DESCRIPTION
scale output loss display by count(total number of element) and not by num(number of vectors) : 
shows mean error per output, making it insensitive to size of predicted vector
+  make scaling optional