### PR TITLE
add option for overweight contours and neigboring pixels

### DIFF
--- a/include/caffe/layers/dice_coef_loss_layer.hpp
+++ b/include/caffe/layers/dice_coef_loss_layer.hpp
@@ -41,7 +41,12 @@ template <typename Dtype>
 class DiceCoefLossLayer : public LossLayer<Dtype> {
  public:
   explicit DiceCoefLossLayer(const LayerParameter& param)
-    : LossLayer<Dtype>(param), multiplier_() ,result_() ,result_tmp_() ,tmp_(),  norm_batch_(false), norm_all_(false),numit_(0), weight_pow_(-2), external_weights_(), has_external_weights_(false) {}
+    : LossLayer<Dtype>(param), multiplier_() ,result_() ,result_tmp_() ,tmp_(),
+    norm_batch_(false), norm_all_(false),
+    numit_(0), weight_pow_(-2), external_weights_(),
+    has_external_weights_(false), do_contour_weights_(false), contour_weights_kernel_(),
+    height_(0), width_(0), mask_inverter_(){}
+    //    contour_weights_() {}
   virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
   virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
@@ -102,6 +107,17 @@ class DiceCoefLossLayer : public LossLayer<Dtype> {
   virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
       const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
 
+protected:
+  void compute_contour_weights_cpu(const Dtype*input, const Dtype*weights,
+                                           Dtype *output);
+
+  void conv_im2col_cpu(const Dtype* data, Dtype* col_buff);
+#ifndef CPU_ONLY
+  void compute_contour_weights_gpu(const Dtype*input, const Dtype*weights,
+                                           Dtype *output);
+  void conv_im2col_gpu(const Dtype* data, Dtype* col_buff);
+#endif
+
   Blob<Dtype> multiplier_;
   Blob<Dtype> result_;
   Blob<Dtype> result_tmp_;
@@ -114,6 +130,7 @@ class DiceCoefLossLayer : public LossLayer<Dtype> {
   Blob<Dtype> weights_;
   Blob<Dtype> weight_multiplier_;
   Blob<Dtype> weights_perclass_mem_;
+  Blob<Dtype> sum_contour_;
   Blob<Dtype> batchsize_multiplier_;
   Blob<Dtype> mask_;
   Dtype smooth_;
@@ -121,6 +138,13 @@ class DiceCoefLossLayer : public LossLayer<Dtype> {
   int weight_pow_;
   Blob<Dtype> external_weights_;
   bool has_external_weights_;
+  bool do_contour_weights_;
+  Blob<Dtype> contour_weights_kernel_;
+  Blob<Dtype> contour_weights_;
+  Blob<Dtype> col_buffer_;
+  int height_;
+  int width_;
+  Blob<Dtype> mask_inverter_;
 };
 
 }  // namespace caffe

--- a/include/caffe/layers/dice_coef_loss_layer.hpp
+++ b/include/caffe/layers/dice_coef_loss_layer.hpp
@@ -45,7 +45,7 @@ class DiceCoefLossLayer : public LossLayer<Dtype> {
     norm_batch_(false), norm_all_(false),
     numit_(0), weight_pow_(-2), external_weights_(),
     has_external_weights_(false), do_contour_weights_(false), contour_weights_kernel_(),
-    height_(0), width_(0), mask_inverter_(){}
+    height_(0), width_(0), mask_inverter_(), contour_amplitude_(5.0){}
     //    contour_weights_() {}
   virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
@@ -145,6 +145,7 @@ protected:
   int height_;
   int width_;
   Blob<Dtype> mask_inverter_;
+  Dtype contour_amplitude_;
 };
 
 }  // namespace caffe

--- a/src/caffe/layers/dice_coef_loss_layer.cpp
+++ b/src/caffe/layers/dice_coef_loss_layer.cpp
@@ -241,8 +241,9 @@ void DiceCoefLossLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
     {
       Dtype unit_weight = Dtype(1.0);
       caffe_set(batchsize*nclasses_, unit_weight, weights_.mutable_cpu_data());
-      for (int i=0; i<batchsize; ++i)
-        caffe_set(1, Dtype(1E6)*Dtype(bottom[1]->count(2)),
+      if (ignore_label_ != -1)
+        for (int i=0; i<batchsize; ++i)
+          caffe_set(1, Dtype(1E6)*Dtype(bottom[1]->count(2)),
                   weights_.mutable_cpu_data()+i*nclasses_+ignore_label_);
       //      compute weights per label per image
       caffe_cpu_gemm(CblasNoTrans, CblasTrans, bottom[1]->num(), bottom[1]->channels(),
@@ -282,7 +283,7 @@ void DiceCoefLossLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
                      weights_.mutable_cpu_data());
 
       //  put them into our multiplexed multiplier
-      caffe_cpu_gemm(CblasTrans, CblasNoTrans,
+      caffe_cpu_gemm(CblasNoTrans, CblasNoTrans,
                      bottom[1]->num(), bottom[1]->count(1), bottom[1]->channels(),
                      Dtype(1.), weights_.cpu_data(), mask_.cpu_data(), Dtype(0.),
                      weight_multiplier_.mutable_cpu_data());

--- a/src/caffe/layers/dice_coef_loss_layer.cu
+++ b/src/caffe/layers/dice_coef_loss_layer.cu
@@ -2,6 +2,7 @@
 
 #include "caffe/layers/dice_coef_loss_layer.hpp"
 #include "caffe/util/math_functions.hpp"
+#include "caffe/util/im2col.hpp"
 
 namespace caffe {
 
@@ -85,11 +86,53 @@ void DiceCoefLossLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
       caffe_gpu_mul(weight_multiplier_.count(), external_weights_.gpu_data(),
                     weight_multiplier_.gpu_data(), weight_multiplier_.mutable_gpu_data());
     }
+  if (do_contour_weights_)
+    {
+      for (int n =0; n<batchsize; ++n)
+        {
+          std::vector<int> old_shape(bottom[1]->shape());
+          std::vector<int> new_shape(bottom[1]->shape());
+          new_shape.insert(new_shape.begin()+2, 1);
+          bottom[1]->Reshape(new_shape);
+          contour_weights_.Reshape(new_shape);
+          // for background , ie class 0, one should revert labels in order for zero padding not
+          // to give much weight to image border
+          caffe_gpu_axpby(height_*width_, Dtype(1.0), mask_inverter_.gpu_data(), Dtype(-1.0),
+                          bottom[1]->mutable_gpu_data()+bottom[1]->offset({n,0,0,0,0}));
+          compute_contour_weights_gpu(bottom[1]->gpu_data()+bottom[1]->offset({n,0,0,0,0}),
+                                      contour_weights_kernel_.gpu_data(),
+                                      contour_weights_.mutable_gpu_data()
+                                      +contour_weights_.offset({n,0,0,0,0}));
+          caffe_gpu_axpby(height_*width_, Dtype(1.0), mask_inverter_.gpu_data(), Dtype(-1.0),
+                          bottom[1]->mutable_gpu_data()+bottom[1]->offset({n,0,0,0,0}));
+
+          for (int c =1; c<nclasses_; ++c)
+              compute_contour_weights_gpu(bottom[1]->gpu_data()+bottom[1]->offset({n,c,0,0,0}),
+                                          contour_weights_kernel_.gpu_data(),
+                                          contour_weights_.mutable_gpu_data()
+                                          +contour_weights_.offset({n,c,0,0,0}));
+          bottom[1]->Reshape(old_shape);
+          contour_weights_.Reshape(old_shape);
+          caffe_gpu_gemv(CblasNoTrans,nclasses_,height_*width_,Dtype(1.0),
+                         contour_weights_.gpu_data()+contour_weights_.offset(n,0,0,0),
+                         multiplier_.gpu_data(), Dtype(0.0),
+                         sum_contour_.mutable_gpu_data()+sum_contour_.offset(n));
+          for (int c =0; c<nclasses_; ++c)
+            {
+              Dtype sum = Dtype(sum_contour_.cpu_data()[sum_contour_.offset({n,c})]);
+              caffe_gpu_scal(height_*width_,
+                             Dtype(height_*width_)/sum,
+                             contour_weights_.mutable_gpu_data()+contour_weights_.offset({n,c,0,0}));
+            }
+        }
+      caffe_gpu_mul(weight_multiplier_.count(), contour_weights_.gpu_data(),
+                    weight_multiplier_.gpu_data(), weight_multiplier_.mutable_gpu_data());
+    }
 
 
   caffe_gpu_mul(count, bottom[0]->gpu_data(), bottom[0]->gpu_data(),
                 tmp_.mutable_gpu_data());
-  if (do_weight_ || has_external_weights_)
+  if (do_weight_ || has_external_weights_ || do_contour_weights_)
     caffe_gpu_mul(bottom[0]->count(), weight_multiplier_.gpu_data(), tmp_.gpu_data(),
 									tmp_.mutable_gpu_data());
 
@@ -99,7 +142,7 @@ void DiceCoefLossLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
 
   caffe_gpu_mul(count, bottom[1]->gpu_data(), bottom[1]->gpu_data(),
                 tmp_.mutable_gpu_data());
-  if (do_weight_ || has_external_weights_)
+  if (do_weight_ || has_external_weights_ || do_contour_weights_)
     caffe_gpu_mul(bottom[0]->count(), weight_multiplier_.gpu_data(), tmp_.gpu_data(),
 									tmp_.mutable_gpu_data());
   caffe_gpu_gemv(CblasNoTrans, bottom[1]->num(), bottom[1]->count(1), Dtype(1.), tmp_.gpu_data(),
@@ -107,7 +150,7 @@ void DiceCoefLossLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
 
 	caffe_gpu_mul(count, bottom[0]->gpu_data(), bottom[1]->gpu_data(),
                 tmp_.mutable_gpu_data());
-  if (do_weight_ || has_external_weights_)
+  if (do_weight_ || has_external_weights_ || do_contour_weights_)
     caffe_gpu_mul(bottom[0]->count(), weight_multiplier_.gpu_data(), tmp_.gpu_data(),
               tmp_.mutable_gpu_data());
   caffe_gpu_gemv(CblasNoTrans, bottom[1]->num(), bottom[1]->count(1), Dtype(2.), tmp_.gpu_data(),
@@ -130,7 +173,6 @@ __global__ void DiceCoefLossBackward(const int n, const Dtype* x,
   CUDA_KERNEL_LOOP(index, n)
     {
       const int i = index / dim;
-			const int imgsize = dim / nclasses;
 			const Dtype alpha = Dtype(-2.) / denominator[i] * sign;
 			Dtype beta = Dtype(2.) * loss[i] / denominator[i] * sign;
 			out_diff[index] = alpha * x[index] + beta * y[index];
@@ -153,11 +195,44 @@ void DiceCoefLossLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
 					bottom[i]->channels(), ignore_label_);
           CUDA_POST_KERNEL_CHECK;
           }
-        if (do_weight_ || has_external_weights_)
+        if (do_weight_ || has_external_weights_ || do_contour_weights_)
           caffe_gpu_mul(bottom[i]->count(), weight_multiplier_.gpu_data(), bottom[i]->gpu_diff(),
                         bottom[i]->mutable_gpu_diff());
   }
 }
+
+
+
+template <typename Dtype>
+void DiceCoefLossLayer<Dtype>::conv_im2col_gpu(const Dtype* data, Dtype* col_buff)
+  {
+    int kh = contour_weights_kernel_.height();
+    im2col_gpu(data, 1,
+               height_, width_,
+               kh,kh,
+               (kh-1)/2, (kh-1)/2,
+               1, 1,
+               1, 1,
+               col_buff);
+ }
+
+
+
+template <typename Dtype>
+void DiceCoefLossLayer<Dtype>::compute_contour_weights_gpu(const Dtype*input, const Dtype*weights,
+                                                             Dtype *output)
+  {
+    conv_im2col_gpu(input, col_buffer_.mutable_gpu_data());
+    const Dtype *col_buff = col_buffer_.gpu_data();
+    caffe_gpu_gemm<Dtype>(CblasNoTrans, CblasNoTrans,
+                          1, contour_weights_.count(3),
+                          contour_weights_kernel_.count(2),
+                          (Dtype)1., weights, col_buff,
+                          (Dtype)0., output) ;
+    caffe_gpu_abs(width_*height_, output, output);
+    caffe_gpu_add_scalar(width_*height_, Dtype(1.0), output);
+  }
+
 
 INSTANTIATE_LAYER_GPU_FUNCS(DiceCoefLossLayer);
 

--- a/src/caffe/layers/dice_coef_loss_layer.cu
+++ b/src/caffe/layers/dice_coef_loss_layer.cu
@@ -56,15 +56,6 @@ void DiceCoefLossLayer<Dtype>::Forward_gpu(const vector<Blob<Dtype>*>& bottom,
                          batchsize_multiplier_.gpu_data(),Dtype(0.0),weights_perclass.mutable_gpu_data());
           caffe_gpu_scal(nclasses_, Dtype(1.0)/Dtype(batchsize), weights_perclass.mutable_gpu_data());
 
-          for (int c=0; c< nclasses_; ++c)
-            {
-              std::cout <<"c: "<< c << std::endl;
-              std::cout <<weights_perclass.cpu_data()[weights_perclass.offset({c})]<<" ";
-              std::cout << std::endl;
-            }
-
-
-
           if (norm_all_)
             {
               if (numit_ != 0)

--- a/src/caffe/layers/dice_coef_loss_layer.cu
+++ b/src/caffe/layers/dice_coef_loss_layer.cu
@@ -231,6 +231,7 @@ void DiceCoefLossLayer<Dtype>::compute_contour_weights_gpu(const Dtype*input, co
                           (Dtype)1., weights, col_buff,
                           (Dtype)0., output) ;
     caffe_gpu_abs(width_*height_, output, output);
+    caffe_gpu_scal(width_*height_, Dtype(contour_amplitude_ - 1.0), output);
     caffe_gpu_add_scalar(width_*height_, Dtype(1.0), output);
   }
 

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -820,15 +820,16 @@ message DiceCoefLossParameter {
 
   optional string weights = 6;
 
-  enum ContourWeights {
+  enum ContourShape {
     NO = 0; // do not apply contour weights
     SIMPLE = 1; // apply simple laplacian mask with -1 everywhere but in center 
     SHARP = 2;  // apply sharper weights than laplacan to more weight close to boundary in case of complex frontier shape 
   }
 
-  optional ContourWeights contour_weights = 7 [default = NO];
+  optional ContourShape contour_shape = 7 [default = NO];
 
   optional int32 contour_size = 8 [default = 7]; // size of conv kernel for contour weights
+  optional float contour_amplitude = 9 [default = 5.0]; // important points are 5 times heavier than common ones
 
   optional int32 ignore_label = 4 [default = -1]; // set to zero to ignore label 0, e.g. background
 }

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -828,7 +828,7 @@ message DiceCoefLossParameter {
 
   optional ContourWeights contour_weights = 7 [default = NO];
 
-  optional int32 contour_size = 8 [default = 3]; // size of conv kernel for contour weights
+  optional int32 contour_size = 8 [default = 7]; // size of conv kernel for contour weights
 
   optional int32 ignore_label = 4 [default = -1]; // set to zero to ignore label 0, e.g. background
 }

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -820,6 +820,16 @@ message DiceCoefLossParameter {
 
   optional string weights = 6;
 
+  enum ContourWeights {
+    NO = 0; // do not apply contour weights
+    SIMPLE = 1; // apply simple laplacian mask with -1 everywhere but in center 
+    SHARP = 2;  // apply sharper weights than laplacan to more weight close to boundary in case of complex frontier shape 
+  }
+
+  optional ContourWeights contour_weights = 7 [default = NO];
+
+  optional int32 contour_size = 8 [default = 3]; // size of conv kernel for contour weights
+
   optional int32 ignore_label = 4 [default = -1]; // set to zero to ignore label 0, e.g. background
 }
 


### PR DESCRIPTION
add pixel weighting so that borderes of classes are more weighted than inside and outside

new options to use in dice loss:
```
dice_coef_loss_param {      
 ...
 contour_shape: SHARP 
 contour_size: 7
contour_amplitude: 5.0
}
```

contour weights are computed with hand made convolutions on masks

- contour_weights can be SIMPLE or SHARP , different convolutions kernels are used, SHARP seems better to give weight to outside pixels in case of sharp contours, while SIMPLE is more regular on smooth contours
- contour_size is the size of the convolution kernel, the bigger it is, the larger is the area of influence. 
- contour_amplitude allows to set relative weights of borders compared to normal pixels: with a value of 5, borders pixels are at most 5 times heavier than normal pixels. For reference, original unet paper allowed up to 10 times heavier
 