### PR TITLE
dice perfo fix: take a flat image as label, and no more multiplexed masks as before

### DIFF
--- a/include/caffe/layers/dice_coef_loss_layer.hpp
+++ b/include/caffe/layers/dice_coef_loss_layer.hpp
@@ -118,6 +118,8 @@ protected:
   void conv_im2col_gpu(const Dtype* data, Dtype* col_buff);
 #endif
 
+
+  Blob<Dtype> one_hot_labels_;
   Blob<Dtype> multiplier_;
   Blob<Dtype> result_;
   Blob<Dtype> result_tmp_;


### PR DESCRIPTION
take a flat image as label, and no more multiplexed masks as before