### PR TITLE
hinton s lookahead

### DIFF
--- a/include/caffe/sgd_solvers.hpp
+++ b/include/caffe/sgd_solvers.hpp
@@ -32,6 +32,9 @@ class SGDSolver : public Solver<Dtype> {
   virtual void Regularize(int param_id);
   virtual void ComputeUpdateValue(int param_id, Dtype rate);
   virtual void ClipGradients();
+  virtual void CopyWeightsToSlow();
+  virtual void CopySlowToWeights();
+  virtual void UpdateSlowWeights();
   virtual void SnapshotSolverState(const string& model_filename);
   virtual void SnapshotSolverStateToBinaryProto(const string& model_filename);
   virtual void SnapshotSolverStateToHDF5(const string& model_filename);
@@ -41,7 +44,7 @@ class SGDSolver : public Solver<Dtype> {
   // update maintains update related data and is not needed in snapshots.
   // temp maintains other information that might be needed in computation
   //   of gradients/updates and is not needed in snapshots
-  vector<shared_ptr<Blob<Dtype> > > history_, update_, temp_;
+  vector<shared_ptr<Blob<Dtype> > > history_, update_, temp_, slow_weights_;
 
   // loss history for 'plateau' LR policy (should be stored in snapshots)
   Dtype minimum_loss_;
@@ -51,6 +54,7 @@ class SGDSolver : public Solver<Dtype> {
   float max_lr_;
   int period_;
   int date_next_restart_;
+  int lookahead_counter_;
 
   DISABLE_COPY_AND_ASSIGN(SGDSolver);
 };

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -400,6 +400,13 @@ message SolverParameter {
   optional float p_mult = 52 [default = 2.0];
   // period before putting back max_lr, -1 means after last iterations, same as putting max_iter
   optional int32 period = 53 [default = -1];
+
+  //below lookahead stuff  
+  optional bool lookahead = 54 [default = false];
+  // number of lookahead steps, 0 means no look ahead,
+  optional int32 lookahead_steps = 55 [default = 6];
+  // weight of lookahead jump
+  optional float lookahead_alpha = 56 [default = 0.5];
 }
 
 // A message that stores the solver snapshots


### PR DESCRIPTION
reference : https://arxiv.org/abs/1907.08610v1

principle is to memorize net params as slow_weights, do  k optim steps to obtain fast_weights and then update slow_weights to slow_weights + \alpha (fast_weights - slow_weights). Hence the subtile : k steps forward, one step back (basically it is 1-\alpha step back)
k is tested around 6 , alpha of 0.5 seems to behave as good as principled, complicated to compute variable value of paper. 

TESTED OK over ADAM 