### PR TITLE
add setter for overlap_threshold in detection_evaluate layer

### DIFF
--- a/include/caffe/layers/detection_evaluate_layer.hpp
+++ b/include/caffe/layers/detection_evaluate_layer.hpp
@@ -32,6 +32,8 @@ class DetectionEvaluateLayer : public Layer<Dtype> {
   virtual inline int ExactBottomBlobs() const { return 2; }
   virtual inline int ExactNumTopBlobs() const { return 1; }
 
+  void set_overlap_threshold(float t) {overlap_threshold_ = t;}
+
  protected:
   /**
    * @brief Evaluate the detection output.


### PR DESCRIPTION
This allows to change on-the-fly threshold for tests in  detection tasks  