### PR TITLE
lr dropout 1912.00144

### DIFF
--- a/include/caffe/util/math_functions.hpp
+++ b/include/caffe/util/math_functions.hpp
@@ -93,6 +93,9 @@ template <typename Dtype>
 void caffe_rng_bernoulli(const int n, const Dtype p, int* r);
 
 template <typename Dtype>
+void caffe_rng_bernoulli_real(const int n, const Dtype p, Dtype* r);
+
+template <typename Dtype>
 void caffe_rng_bernoulli(const int n, const Dtype p, unsigned int* r);
 
 template <typename Dtype>
@@ -240,6 +243,9 @@ void caffe_gpu_rng_uniform(const int n, unsigned int* r);
 // appropriately after calling curandGenerateUniform.
 template <typename Dtype>
 void caffe_gpu_rng_uniform(const int n, const Dtype a, const Dtype b, Dtype* r);
+
+template <typename Dtype>
+void caffe_gpu_rng_uniform01(const int n, Dtype* r);
 
 template <typename Dtype>
 void caffe_gpu_rng_gaussian(const int n, const Dtype mu, const Dtype sigma,

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -317,6 +317,7 @@ message SolverParameter {
   optional float power = 10; // The parameter to compute the learning rate.
   optional float momentum = 11; // The momentum value.
   optional float weight_decay = 12; // The weight decay.
+  optional float lr_dropout = 62 [default = 1.0]; // learning rate dropout as in 1912.00144
   optional int32 decoupled_wd_t0 = 60 [default = 1000]; // decoupled weight decay initial budget
   optional float decoupled_wd_mult = 61 [default = 2]; // decoupled weight decay multiplier
     // regularization types supported: L1 and L2

--- a/src/caffe/solvers/sgd_solver.cu
+++ b/src/caffe/solvers/sgd_solver.cu
@@ -5,8 +5,23 @@ namespace caffe {
 
 template <typename Dtype>
 __global__ void SGDUpdate(int N, Dtype* g, Dtype* h, const Dtype* param,
-                          Dtype momentum, Dtype local_rate, Dtype lambda, Dtype nu, bool decoupled) {
+                          Dtype momentum, Dtype local_rate, Dtype lambda, Dtype nu, bool decoupled,
+                          Dtype lr_dropout, const Dtype*r) {
   CUDA_KERNEL_LOOP(i, N) {
+    if (lr_dropout == 1.0)
+      {
+        if (decoupled)
+          g[i] = h[i] = momentum*h[i] + local_rate*g[i] * nu + param[i] * lambda * nu;
+        else
+          g[i] = h[i] = momentum*h[i] + local_rate*g[i];
+        return;
+      }
+
+    if (r[i] > lr_dropout)
+      {
+        g[i] = h[i] = Dtype(0.0);
+        return;
+      }
     if (decoupled)
       g[i] = h[i] = momentum*h[i] + local_rate*g[i] * nu + param[i] * lambda * nu;
     else
@@ -15,13 +30,15 @@ __global__ void SGDUpdate(int N, Dtype* g, Dtype* h, const Dtype* param,
 }
 template <typename Dtype>
 void sgd_update_gpu(int N, Dtype* g, Dtype* h, const Dtype * param, Dtype momentum,
-  Dtype local_rate, Dtype lambda, Dtype nu, bool decoupled) {
+                    Dtype local_rate, Dtype lambda, Dtype nu, bool decoupled, Dtype lr_dropout,
+                    const Dtype *r) {
+
   SGDUpdate<Dtype>  // NOLINT_NEXT_LINE(whitespace/operators)
       <<<CAFFE_GET_BLOCKS(N), CAFFE_CUDA_NUM_THREADS>>>(
-      N, g, h, param, momentum, local_rate , nu, lambda, decoupled);
+                           N, g, h, param, momentum, local_rate , nu, lambda, decoupled, lr_dropout,r);
   CUDA_POST_KERNEL_CHECK;
 }
-  template void sgd_update_gpu<float>(int, float*, float*, const float*, float, float, float, float, bool);
-  template void sgd_update_gpu<double>(int, double*, double*, const double*, double, double, double, double, bool);
+  template void sgd_update_gpu<float>(int, float*, float*, const float*, float, float, float, float, bool, float, const float*);
+  template void sgd_update_gpu<double>(int, double*, double*, const double*, double, double, double, double, bool, double, const double*);
 
 }  // namespace caffe

--- a/src/caffe/util/math_functions.cpp
+++ b/src/caffe/util/math_functions.cpp
@@ -446,6 +446,28 @@ void caffe_rng_bernoulli<double>(const int n, const double p, int* r);
 template
 void caffe_rng_bernoulli<float>(const int n, const float p, int* r);
 
+
+template <typename Dtype>
+  void caffe_rng_bernoulli_real(const int n, const Dtype p, Dtype* r) {
+    CHECK_GE(n, 0);
+    CHECK(r);
+    CHECK_GE(p, 0);
+    CHECK_LE(p, 1);
+    boost::bernoulli_distribution<Dtype> random_distribution(p);
+    boost::variate_generator<caffe::rng_t*, boost::bernoulli_distribution<Dtype> >
+      variate_generator(caffe_rng(), random_distribution);
+    for (int i = 0; i < n; ++i) {
+      r[i] = (float)variate_generator();
+    }
+  }
+
+
+template
+void caffe_rng_bernoulli_real<float>(const int n, const float p, float* r);
+
+template
+void caffe_rng_bernoulli_real<double>(const int n, const double p, double* r);
+
 template <typename Dtype>
 void caffe_rng_bernoulli(const int n, const Dtype p, unsigned int* r) {
   CHECK_GE(n, 0);

--- a/src/caffe/util/math_functions.cu
+++ b/src/caffe/util/math_functions.cu
@@ -399,6 +399,17 @@ void caffe_gpu_rng_uniform(const int n, unsigned int* r) {
 }
 
 template <>
+void caffe_gpu_rng_uniform01<float>(const int n, float* r) {
+    CAFFE1_CURAND_CHECK(curandGenerateUniform(Caffe::curand_generator(), r, n));
+}
+
+template <>
+void caffe_gpu_rng_uniform01<double>(const int n, double* r) {
+  CAFFE1_CURAND_CHECK(curandGenerateUniformDouble(Caffe::curand_generator(), r, n));
+}
+
+
+template <>
 void caffe_gpu_rng_uniform<float>(const int n, const float a, const float b,
                                   float* r) {
   CAFFE1_CURAND_CHECK(curandGenerateUniform(Caffe::curand_generator(), r, n));


### PR DESCRIPTION
TESTED OK : consistently better with several solvers, at no cost 

https://arxiv.org/abs/1912.00144

lr dropout simply set to zero update value of some components of the gradient with some probability. difference with other noise adding methods is that general direction of the exact gradient is respected 
default : disabled (ie unchanged ratio = 1-dropout ratio = 1.0)