### PR TITLE
remove deprecation warnings , compiles for sm75

### DIFF
--- a/include/caffe/3rdparty/moderngpu/include/device/intrinsics.cuh
+++ b/include/caffe/3rdparty/moderngpu/include/device/intrinsics.cuh
@@ -112,7 +112,7 @@ __device__ __forceinline__ float shfl_up(float var,
 	unsigned int delta, int width = 32) {
 
 #if __CUDA_ARCH__ >= 300
-	var = __shfl_up(var, delta, width);
+  var = __shfl_up_sync(0xFFFFFFFF,var, delta, width);
 #endif
 	return var;
 }
@@ -122,8 +122,8 @@ __device__ __forceinline__ double shfl_up(double var,
 
 #if __CUDA_ARCH__ >= 300
 	int2 p = mgpu::double_as_int2(var);
-	p.x = __shfl_up(p.x, delta, width);
-	p.y = __shfl_up(p.y, delta, width);
+	p.x = __shfl_up_sync(0xFFFFFFFF,p.x, delta, width);
+	p.y = __shfl_up_sync(0xFFFFFFFF,p.y, delta, width);
 	var = mgpu::int2_as_double(p);
 #endif
 
@@ -140,7 +140,7 @@ MGPU_DEVICE int shfl_add(int x, int offset, int width = WARP_SIZE) {
 	asm(
 		"{.reg .s32 r0;"
 		".reg .pred p;"
-		"shfl.up.b32 r0|p, %1, %2, %3;"
+		"shfl.sync.up.b32 r0|p, %1, %2, %3, 0xffffffff;"
 		"@p add.s32 r0, r0, %4;"
 		"mov.s32 %0, r0; }"
 		: "=r"(result) : "r"(x), "r"(offset), "r"(mask), "r"(x));
@@ -155,7 +155,7 @@ MGPU_DEVICE int shfl_max(int x, int offset, int width = WARP_SIZE) {
 	asm(
 		"{.reg .s32 r0;"
 		".reg .pred p;"
-		"shfl.up.b32 r0|p, %1, %2, %3;"
+		"shfl.sync.up.b32 r0|p, %1, %2, %3, 0xffffffff;"
 		"@p max.s32 r0, r0, %4;"
 		"mov.s32 %0, r0; }"
 		: "=r"(result) : "r"(x), "r"(offset), "r"(mask), "r"(x));

--- a/src/caffe/3rdparty/ctc/reduce.cu
+++ b/src/caffe/3rdparty/ctc/reduce.cu
@@ -41,7 +41,7 @@ struct CTAReduce {
 
         T shuff;
         for (int offset = warp_size / 2; offset > 0; offset /= 2) {
-            shuff = __shfl_down(x, offset);
+            shuff = __shfl_down_sync(0xFFFFFFFF,x, offset);
             if (tid + offset < count && tid < offset)
                 x = g(x, shuff);
         }

--- a/src/caffe/layers/dice_coef_loss_layer.cu
+++ b/src/caffe/layers/dice_coef_loss_layer.cu
@@ -195,7 +195,6 @@ void DiceCoefLossLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
           {
           int count = bottom[i]->count();
           const Dtype sign = Dtype(1.0)*top[0]->cpu_diff()[0];
-          const int index = (i == 0) ? 1 : 0;
           DiceCoefLossBackward<Dtype><<<CAFFE_GET_BLOCKS(count), CAFFE_CUDA_NUM_THREADS>>>(
           count, one_hot_labels_.gpu_data(), bottom[i]->gpu_data(), bottom[i]->mutable_gpu_diff(),
 					sign, result_.gpu_data(), result_tmp_.gpu_data(), bottom[i]->count(1),

--- a/src/caffe/util/math_functions.cu
+++ b/src/caffe/util/math_functions.cu
@@ -1,4 +1,4 @@
-#include <math_functions.h>  // CUDA's, not caffe's, for fabs, signbit
+#include <cuda_runtime_api.h>
 #include <thrust/device_vector.h>
 #include <thrust/functional.h>  // thrust::plus
 #include <thrust/reduce.h>


### PR DESCRIPTION
TESTED OK

this PR add small changes to the header inclusion and removes deprecated (since cuda 9) shfl_[up|down]*  with sync'ed version
this change allows compilation wrt sm75