### PR TITLE
save a lot of cudnn unfreed memory 

### DIFF
--- a/include/caffe/layers/cudnn_deconv_layer.hpp
+++ b/include/caffe/layers/cudnn_deconv_layer.hpp
@@ -25,7 +25,26 @@ template <typename Dtype>
 class CuDNNDeconvolutionLayer : public DeconvolutionLayer<Dtype> {
  public:
   explicit CuDNNDeconvolutionLayer(const LayerParameter& param)
-    : DeconvolutionLayer<Dtype>(param), handles_setup_(false) {}
+    : DeconvolutionLayer<Dtype>(param), handles_setup_(false)
+  {
+    switch (param.convolution_param().cudnn_flavor())
+      {
+      case ConvolutionParameter::SINGLE_HANDLE:
+        multiple_handles_ = false;
+        min_memory_ = false;
+        break;
+      case ConvolutionParameter::MULTIPLE_HANDLES:
+        multiple_handles_ = true;
+        break;
+      case ConvolutionParameter::MIN_MEMORY:
+        multiple_handles_ = false;
+        min_memory_ = true;
+        break;
+      default:
+        multiple_handles_ = false;
+        min_memory_ = false;
+      }
+  }
   virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
                           const vector<Blob<Dtype>*>& top);
   virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
@@ -47,6 +66,14 @@ class CuDNNDeconvolutionLayer : public DeconvolutionLayer<Dtype> {
   cudnnConvolutionFwdAlgo_t *fwd_algo_;
   cudnnConvolutionBwdFilterAlgo_t *bwd_filter_algo_;
   cudnnConvolutionBwdDataAlgo_t *bwd_data_algo_;
+
+  bool multiple_handles_;
+  bool min_memory_;
+#if CUDNN_VERSION_MIN(7,0,0)
+  std::vector<cudnnConvolutionFwdAlgoPerf_t> fwdPerf_;
+  std::vector<cudnnConvolutionBwdFilterAlgoPerf_t> bwdFilterPerf_;
+  std::vector<cudnnConvolutionBwdDataAlgoPerf_t> bwdDataPerf_;
+#endif
 
   vector<cudnnTensorDescriptor_t> bottom_descs_, top_descs_;
   cudnnTensorDescriptor_t bias_desc_;

--- a/src/caffe/layers/cudnn_conv_layer.cpp
+++ b/src/caffe/layers/cudnn_conv_layer.cpp
@@ -6,264 +6,404 @@
 
 namespace caffe {
 
-// Set to three for the benefit of the backward pass, which
-// can use separate streams for calculating the gradient w.r.t.
-// bias, filter weights, and bottom data for each group independently
+  // Set to three for the benefit of the backward pass, which
+  // can use separate streams for calculating the gradient w.r.t.
+  // bias, filter weights, and bottom data for each group independently
 #define CUDNN_STREAMS_PER_GROUP 3
 
-/**
- * TODO(dox) explain cuDNN interface
- */
-template <typename Dtype>
-void CuDNNConvolutionLayer<Dtype>::LayerSetUp(
-    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
-  ConvolutionLayer<Dtype>::LayerSetUp(bottom, top);
-  // Initialize CUDA streams and cuDNN.
-  stream_         = new cudaStream_t[this->group_ * CUDNN_STREAMS_PER_GROUP];
-  handle_         = new cudnnHandle_t[this->group_ * CUDNN_STREAMS_PER_GROUP];
+  /**
+   * TODO(dox) explain cuDNN interface
+   */
+  template <typename Dtype>
+  void CuDNNConvolutionLayer<Dtype>::LayerSetUp(
+                                                const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+    ConvolutionLayer<Dtype>::LayerSetUp(bottom, top);
+    // Initialize CUDA streams and cuDNN.
 
-  // Initialize algorithm arrays
-  fwd_algo_       = new cudnnConvolutionFwdAlgo_t[bottom.size()];
-  bwd_filter_algo_= new cudnnConvolutionBwdFilterAlgo_t[bottom.size()];
-  bwd_data_algo_  = new cudnnConvolutionBwdDataAlgo_t[bottom.size()];
 
-  // initialize size arrays
-  workspace_fwd_sizes_ = new size_t[bottom.size()];
-  workspace_bwd_filter_sizes_ = new size_t[bottom.size()];
-  workspace_bwd_data_sizes_ = new size_t[bottom.size()];
 
-  // workspace data
-  workspaceSizeInBytes = 0;
-  workspaceData = NULL;
-  workspace = new void*[this->group_ * CUDNN_STREAMS_PER_GROUP];
+    workspaceSizeInBytes = 0;
+    workspaceData = NULL;
+#if CUDNN_VERSION_MIN(7,0,0)
+    if (multiple_handles_)
+      {
+#endif
+        stream_         = new cudaStream_t[this->group_ * CUDNN_STREAMS_PER_GROUP];
+        handle_         = new cudnnHandle_t[this->group_ * CUDNN_STREAMS_PER_GROUP];
+        // Initialize algorithm arrays
+        fwd_algo_       = new cudnnConvolutionFwdAlgo_t[bottom.size()];
+        bwd_filter_algo_= new cudnnConvolutionBwdFilterAlgo_t[bottom.size()];
+        bwd_data_algo_  = new cudnnConvolutionBwdDataAlgo_t[bottom.size()];
+        // initialize size arrays
+        workspace_fwd_sizes_ = new size_t[bottom.size()];
+        workspace_bwd_filter_sizes_ = new size_t[bottom.size()];
+        workspace_bwd_data_sizes_ = new size_t[bottom.size()];
+        workspace = new void*[this->group_ * CUDNN_STREAMS_PER_GROUP];
+        for (size_t i = 0; i < bottom.size(); ++i) {
+          // initialize all to default algorithms
+          fwd_algo_[i] = (cudnnConvolutionFwdAlgo_t)0;
+          bwd_filter_algo_[i] = (cudnnConvolutionBwdFilterAlgo_t)0;
+          bwd_data_algo_[i] = (cudnnConvolutionBwdDataAlgo_t)0;
+          // default algorithms don't require workspace
+          workspace_fwd_sizes_[i] = 0;
+          workspace_bwd_data_sizes_[i] = 0;
+          workspace_bwd_filter_sizes_[i] = 0;
+        }
+        for (int g = 0; g < this->group_ * CUDNN_STREAMS_PER_GROUP; g++) {
+          CAFFE1_CUDA_CHECK(cudaStreamCreate(&stream_[g]));
+          CUDNN_CHECK(cudnnCreate(&handle_[g]));
+          CUDNN_CHECK(cudnnSetStream(handle_[g], stream_[g]));
+          workspace[g] = NULL;
+        }
+        bias_offset_ = (this->num_output_ / this->group_);
 
-  for (size_t i = 0; i < bottom.size(); ++i) {
-    // initialize all to default algorithms
-    fwd_algo_[i] = (cudnnConvolutionFwdAlgo_t)0;
-    bwd_filter_algo_[i] = (cudnnConvolutionBwdFilterAlgo_t)0;
-    bwd_data_algo_[i] = (cudnnConvolutionBwdDataAlgo_t)0;
-    // default algorithms don't require workspace
-    workspace_fwd_sizes_[i] = 0;
-    workspace_bwd_data_sizes_[i] = 0;
-    workspace_bwd_filter_sizes_[i] = 0;
+#if CUDNN_VERSION_MIN(7,0,0)
+      }
+    else
+      {
+        handle_         = new cudnnHandle_t[1];
+        fwdPerf_.resize(bottom.size());
+        bwdFilterPerf_.resize(bottom.size());
+        bwdDataPerf_.resize(bottom.size());
+        CUDNN_CHECK(cudnnCreate(&handle_[0]));
+      }
+#endif
+
+    // Create filter descriptor.
+    const int* kernel_shape_data = this->kernel_shape_.cpu_data();
+    const int kernel_h = kernel_shape_data[0];
+    const int kernel_w = kernel_shape_data[1];
+
+#if CUDNN_VERSION_MIN(7,0,0)
+    if (multiple_handles_)
+#endif
+      cudnn::createFilterDesc<Dtype>(&filter_desc_,
+                                     this->num_output_ / this->group_, this->channels_ / this->group_,
+                                     kernel_h, kernel_w);
+#if CUDNN_VERSION_MIN(7,0,0)
+    else
+      cudnn::createFilterDesc<Dtype>(&filter_desc_, this->num_output_, this->channels_ / this->group_,
+                                     kernel_h, kernel_w);
+#endif
+
+    // Create tensor descriptor(s) for data and corresponding convolution(s).
+    for (int i = 0; i < bottom.size(); i++) {
+      cudnnTensorDescriptor_t bottom_desc;
+      cudnn::createTensor4dDesc<Dtype>(&bottom_desc);
+      bottom_descs_.push_back(bottom_desc);
+      cudnnTensorDescriptor_t top_desc;
+      cudnn::createTensor4dDesc<Dtype>(&top_desc);
+      top_descs_.push_back(top_desc);
+      cudnnConvolutionDescriptor_t conv_desc;
+      cudnn::createConvolutionDesc<Dtype>(&conv_desc);
+      conv_descs_.push_back(conv_desc);
+    }
+
+    // Tensor descriptor for bias.
+    if (this->bias_term_) {
+      cudnn::createTensor4dDesc<Dtype>(&bias_desc_);
+    }
+
+    handles_setup_ = true;
   }
 
-  for (int g = 0; g < this->group_ * CUDNN_STREAMS_PER_GROUP; g++) {
-    CAFFE1_CUDA_CHECK(cudaStreamCreate(&stream_[g]));
-    CUDNN_CHECK(cudnnCreate(&handle_[g]));
-    CUDNN_CHECK(cudnnSetStream(handle_[g], stream_[g]));
-    workspace[g] = NULL;
-  }
-
-  // Set the indexing parameters.
-  bias_offset_ = (this->num_output_ / this->group_);
-
-  // Create filter descriptor.
-  const int* kernel_shape_data = this->kernel_shape_.cpu_data();
-  const int kernel_h = kernel_shape_data[0];
-  const int kernel_w = kernel_shape_data[1];
-  cudnn::createFilterDesc<Dtype>(&filter_desc_,
-      this->num_output_ / this->group_, this->channels_ / this->group_,
-      kernel_h, kernel_w);
-
-  // Create tensor descriptor(s) for data and corresponding convolution(s).
-  for (int i = 0; i < bottom.size(); i++) {
-    cudnnTensorDescriptor_t bottom_desc;
-    cudnn::createTensor4dDesc<Dtype>(&bottom_desc);
-    bottom_descs_.push_back(bottom_desc);
-    cudnnTensorDescriptor_t top_desc;
-    cudnn::createTensor4dDesc<Dtype>(&top_desc);
-    top_descs_.push_back(top_desc);
-    cudnnConvolutionDescriptor_t conv_desc;
-    cudnn::createConvolutionDesc<Dtype>(&conv_desc);
-    conv_descs_.push_back(conv_desc);
-  }
-
-  // Tensor descriptor for bias.
-  if (this->bias_term_) {
-    cudnn::createTensor4dDesc<Dtype>(&bias_desc_);
-  }
-
-  handles_setup_ = true;
-}
-
-template <typename Dtype>
-void CuDNNConvolutionLayer<Dtype>::Reshape(
-    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
-  ConvolutionLayer<Dtype>::Reshape(bottom, top);
-  CHECK_EQ(2, this->num_spatial_axes_)
+  template <typename Dtype>
+  void CuDNNConvolutionLayer<Dtype>::Reshape(
+                                             const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+    ConvolutionLayer<Dtype>::Reshape(bottom, top);
+    CHECK_EQ(2, this->num_spatial_axes_)
       << "CuDNNConvolution input must have 2 spatial axes "
       << "(e.g., height and width). "
       << "Use 'engine: CAFFE' for general ND convolution.";
-  bottom_offset_ = this->bottom_dim_ / this->group_;
-  top_offset_ = this->top_dim_ / this->group_;
-  const int height = bottom[0]->shape(this->channel_axis_ + 1);
-  const int width = bottom[0]->shape(this->channel_axis_ + 2);
-  const int height_out = top[0]->shape(this->channel_axis_ + 1);
-  const int width_out = top[0]->shape(this->channel_axis_ + 2);
-  const int* pad_data = this->pad_.cpu_data();
-  const int pad_h = pad_data[0];
-  const int pad_w = pad_data[1];
-  const int* stride_data = this->stride_.cpu_data();
-  const int stride_h = stride_data[0];
-  const int stride_w = stride_data[1];
+#if CUDNN_VERSION_MIN(7,0,0)
+    if (multiple_handles_)
+      {
+#endif
+        bottom_offset_ = this->bottom_dim_ / this->group_;
+        top_offset_ = this->top_dim_ / this->group_;
+#if CUDNN_VERSION_MIN(7,0,0)
+      }
+#endif
+    const int height = bottom[0]->shape(this->channel_axis_ + 1);
+    const int width = bottom[0]->shape(this->channel_axis_ + 2);
+    const int height_out = top[0]->shape(this->channel_axis_ + 1);
+    const int width_out = top[0]->shape(this->channel_axis_ + 2);
+    const int* pad_data = this->pad_.cpu_data();
+    const int pad_h = pad_data[0];
+    const int pad_w = pad_data[1];
+    const int* stride_data = this->stride_.cpu_data();
+    const int stride_h = stride_data[0];
+    const int stride_w = stride_data[1];
 
-  // Specify workspace limit for kernels directly until we have a
-  // planning strategy and a rewrite of Caffe's GPU memory mangagement
-  size_t workspace_limit_bytes = 8*1024*1024;
+    // Specify workspace limit for kernels directly until we have a
+    // planning strategy and a rewrite of Caffe's GPU memory mangagement
 
-  for (int i = 0; i < bottom.size(); i++) {
-    cudnn::setTensor4dDesc<Dtype>(&bottom_descs_[i],
-        this->num_,
-        this->channels_ / this->group_, height, width,
-        this->channels_ * height * width,
-        height * width, width, 1);
-    cudnn::setTensor4dDesc<Dtype>(&top_descs_[i],
-        this->num_,
-        this->num_output_ / this->group_, height_out, width_out,
-        this->num_output_ * this->out_spatial_dim_,
-        this->out_spatial_dim_, width_out, 1);
-    cudnn::setConvolutionDesc<Dtype>(&conv_descs_[i], bottom_descs_[i],
-        filter_desc_, pad_h, pad_w,
-        stride_h, stride_w);
 
-    // choose forward and backward algorithms + workspace(s)
-    CUDNN_CHECK(cudnnGetConvolutionForwardAlgorithm(handle_[0],
-      bottom_descs_[i],
-      filter_desc_,
-      conv_descs_[i],
-      top_descs_[i],
-      CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT,
-      workspace_limit_bytes,
-      &fwd_algo_[i]));
+    for (int i = 0; i < bottom.size(); i++)
+      {
+#if CUDNN_VERSION_MIN(7,0,0)
+        if (multiple_handles_)
+          {
+#endif
+            size_t workspace_limit_bytes = 8*1024*1024;
 
-    CUDNN_CHECK(cudnnGetConvolutionForwardWorkspaceSize(handle_[0],
-      bottom_descs_[i],
-      filter_desc_,
-      conv_descs_[i],
-      top_descs_[i],
-      fwd_algo_[i],
-      &(workspace_fwd_sizes_[i])));
+            cudnn::setTensor4dDesc<Dtype>(&bottom_descs_[i],
+                                          this->num_,
+                                          this->channels_ / this->group_, height, width,
+                                          this->channels_ * height * width,
+                                          height * width, width, 1);
+            cudnn::setTensor4dDesc<Dtype>(&top_descs_[i],
+                                          this->num_,
+                                          this->num_output_ / this->group_, height_out, width_out,
+                                          this->num_output_ * this->out_spatial_dim_,
+                                          this->out_spatial_dim_, width_out, 1);
+            cudnn::setConvolutionDesc<Dtype>(&conv_descs_[i], bottom_descs_[i],
+                                             filter_desc_, pad_h, pad_w,
+                                             stride_h, stride_w);
+            // choose forward and backward algorithms + workspace(s)
+            CUDNN_CHECK(cudnnGetConvolutionForwardAlgorithm(handle_[0],
+                                                            bottom_descs_[i],
+                                                            filter_desc_,
+                                                            conv_descs_[i],
+                                                            top_descs_[i],
+                                                            CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT,
+                                                            workspace_limit_bytes,
+                                                            &fwd_algo_[i]));
 
-    // choose backward algorithm for filter
-    CUDNN_CHECK(cudnnGetConvolutionBackwardFilterAlgorithm(handle_[0],
-          bottom_descs_[i], top_descs_[i], conv_descs_[i], filter_desc_,
-          CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT,
-          workspace_limit_bytes, &bwd_filter_algo_[i]) );
+            CUDNN_CHECK(cudnnGetConvolutionForwardWorkspaceSize(handle_[0],
+                                                                bottom_descs_[i],
+                                                                filter_desc_,
+                                                                conv_descs_[i],
+                                                                top_descs_[i],
+                                                                fwd_algo_[i],
+                                                                &(workspace_fwd_sizes_[i])));
 
-    // get workspace for backwards filter algorithm
-    CUDNN_CHECK(cudnnGetConvolutionBackwardFilterWorkspaceSize(handle_[0],
-          bottom_descs_[i], top_descs_[i], conv_descs_[i], filter_desc_,
-          bwd_filter_algo_[i], &workspace_bwd_filter_sizes_[i]));
+            // choose backward algorithm for filter
+            CUDNN_CHECK(cudnnGetConvolutionBackwardFilterAlgorithm(
+                                                                   handle_[0],
+                                                                   bottom_descs_[i], top_descs_[i], conv_descs_[i], filter_desc_,
+                                                                   CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT,
+                                                                   workspace_limit_bytes, &bwd_filter_algo_[i]) );
 
-    // choose backward algo for data
-    CUDNN_CHECK(cudnnGetConvolutionBackwardDataAlgorithm(handle_[0],
-          filter_desc_, top_descs_[i], conv_descs_[i], bottom_descs_[i],
-          CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT,
-        workspace_limit_bytes, &bwd_data_algo_[i]));
+            // get workspace for backwards filter algorithm
+            CUDNN_CHECK(cudnnGetConvolutionBackwardFilterWorkspaceSize(handle_[0],
+                                                                       bottom_descs_[i], top_descs_[i], conv_descs_[i], filter_desc_,
+                                                                       bwd_filter_algo_[i], &workspace_bwd_filter_sizes_[i]));
 
-    // get workspace size
-    CUDNN_CHECK(cudnnGetConvolutionBackwardDataWorkspaceSize(handle_[0],
-          filter_desc_, top_descs_[i], conv_descs_[i], bottom_descs_[i],
-          bwd_data_algo_[i], &workspace_bwd_data_sizes_[i]) );
-  }
+            // choose backward algo for data
+            CUDNN_CHECK(cudnnGetConvolutionBackwardDataAlgorithm(handle_[0],
+                                                                 filter_desc_, top_descs_[i], conv_descs_[i], bottom_descs_[i],
+                                                                 CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT,
+                                                                 workspace_limit_bytes, &bwd_data_algo_[i]));
 
-  // reduce over all workspace sizes to get a maximum to allocate / reallocate
-  size_t total_workspace_fwd = 0;
-  size_t total_workspace_bwd_data = 0;
-  size_t total_workspace_bwd_filter = 0;
+            // get workspace size
+            CUDNN_CHECK(cudnnGetConvolutionBackwardDataWorkspaceSize(handle_[0],
+                                                                     filter_desc_, top_descs_[i], conv_descs_[i], bottom_descs_[i],
+                                                                     bwd_data_algo_[i], &workspace_bwd_data_sizes_[i]) );
 
-  for (size_t i = 0; i < bottom.size(); i++) {
-    total_workspace_fwd        = std::max(total_workspace_fwd,
-                                     workspace_fwd_sizes_[i]);
-    total_workspace_bwd_data   = std::max(total_workspace_bwd_data,
-                                     workspace_bwd_data_sizes_[i]);
-    total_workspace_bwd_filter = std::max(total_workspace_bwd_filter,
-                                     workspace_bwd_filter_sizes_[i]);
-  }
-  // get max over all operations
-  size_t max_workspace = std::max(total_workspace_fwd,
-                             total_workspace_bwd_data);
-  max_workspace = std::max(max_workspace, total_workspace_bwd_filter);
-  // ensure all groups have enough workspace
-  size_t total_max_workspace = max_workspace *
-                               (this->group_ * CUDNN_STREAMS_PER_GROUP);
+            // reduce over all workspace sizes to get a maximum to allocate / reallocate
+            size_t total_workspace_fwd = 0;
+            size_t total_workspace_bwd_data = 0;
+            size_t total_workspace_bwd_filter = 0;
 
-  // this is the total amount of storage needed over all groups + streams
-  if (total_max_workspace > workspaceSizeInBytes) {
-    DLOG(INFO) << "Reallocating workspace storage: " << total_max_workspace;
-    workspaceSizeInBytes = total_max_workspace;
+            for (size_t i = 0; i < bottom.size(); i++) {
+              total_workspace_fwd        = std::max(total_workspace_fwd,
+                                                    workspace_fwd_sizes_[i]);
+              total_workspace_bwd_data   = std::max(total_workspace_bwd_data,
+                                                    workspace_bwd_data_sizes_[i]);
+              total_workspace_bwd_filter = std::max(total_workspace_bwd_filter,
+                                                    workspace_bwd_filter_sizes_[i]);
+            }
+            // get max over all operations
+            size_t max_workspace = std::max(total_workspace_fwd,
+                                            total_workspace_bwd_data);
+            max_workspace = std::max(max_workspace, total_workspace_bwd_filter);
+            // ensure all groups have enough workspace
 
-    // free the existing workspace and allocate a new (larger) one
-    cudaFree(this->workspaceData);
+            size_t total_max_workspace;
+            total_max_workspace =  max_workspace * (this->group_ * CUDNN_STREAMS_PER_GROUP);
 
-    cudaError_t err = cudaMalloc(&(this->workspaceData), workspaceSizeInBytes);
-    if (err != cudaSuccess) {
-      // force zero memory path
-      for (int i = 0; i < bottom.size(); i++) {
-        workspace_fwd_sizes_[i] = 0;
-        workspace_bwd_filter_sizes_[i] = 0;
-        workspace_bwd_data_sizes_[i] = 0;
-        fwd_algo_[i] = CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM;
-        bwd_filter_algo_[i] = CUDNN_CONVOLUTION_BWD_FILTER_ALGO_0;
-        bwd_data_algo_[i] = CUDNN_CONVOLUTION_BWD_DATA_ALGO_0;
+            // this is the total amount of storage needed over all groups + streams
+            if (total_max_workspace > workspaceSizeInBytes)
+              {
+                DLOG(INFO) << "Reallocating workspace storage: " << total_max_workspace;
+                workspaceSizeInBytes = total_max_workspace;
+
+                // free the existing workspace and allocate a new (larger) one
+                cudaFree(this->workspaceData);
+
+                cudaError_t err = cudaMalloc(&(this->workspaceData), workspaceSizeInBytes);
+                if (err != cudaSuccess) {
+                  // force zero memory path
+                  for (int i = 0; i < bottom.size(); i++) {
+                    workspace_fwd_sizes_[i] = 0;
+                    workspace_bwd_filter_sizes_[i] = 0;
+                    workspace_bwd_data_sizes_[i] = 0;
+                    fwd_algo_[i] = CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM;
+                    bwd_filter_algo_[i] = CUDNN_CONVOLUTION_BWD_FILTER_ALGO_0;
+                    bwd_data_algo_[i] = CUDNN_CONVOLUTION_BWD_DATA_ALGO_0;
+                  }
+
+                  // NULL out all workspace pointers
+                  for (int g = 0; g < (this->group_ * CUDNN_STREAMS_PER_GROUP); g++) {
+                    workspace[g] = NULL;
+                  }
+                  // NULL out underlying data
+                  workspaceData = NULL;
+                  workspaceSizeInBytes = 0;
+                }
+
+                // if we succeed in the allocation, set pointer aliases for workspaces
+                for (int g = 0; g < (this->group_ * CUDNN_STREAMS_PER_GROUP); g++) {
+                  workspace[g] = reinterpret_cast<char *>(workspaceData) + g*max_workspace;
+                }
+
+              }
+#if CUDNN_VERSION_MIN(7,0,0)
+          }
+        else
+          {
+            cudnn::setTensor4dDesc<Dtype>(&bottom_descs_[i],
+                                          this->num_,
+                                          this->channels_, height, width,
+                                          this->channels_ * height * width,
+                                          height * width, width, 1);
+            cudnn::setTensor4dDesc<Dtype>(&top_descs_[i],
+                                          this->num_,
+                                          this->num_output_, height_out, width_out,
+                                          this->num_output_ * this->out_spatial_dim_,
+                                          this->out_spatial_dim_, width_out, 1);
+            cudnn::setConvolutionDesc<Dtype>(&conv_descs_[i], bottom_descs_[i],
+                                             filter_desc_, pad_h, pad_w,
+                                             stride_h, stride_w);
+
+            cudnnSetConvolutionGroupCount(conv_descs_[i], this->group_);
+
+            if (!min_memory_)
+              {
+                int num_algs_fwd;
+                cudnnGetConvolutionForwardAlgorithm_v7(handle_[0],
+                                                       bottom_descs_[i],
+                                                       filter_desc_,
+                                                       conv_descs_[i],
+                                                       top_descs_[i],
+                                                       1,
+                                                       &num_algs_fwd,
+                                                       &fwdPerf_[i]);
+                if (fwdPerf_[i].memory > workspaceSizeInBytes)
+                  workspaceSizeInBytes = fwdPerf_[i].memory;
+
+                cudnnSetConvolutionMathType(conv_descs_[i],fwdPerf_[i].mathType);
+
+                int num_algs_bwd_filter;
+                cudnnGetConvolutionBackwardFilterAlgorithm_v7(handle_[0],
+                                                              bottom_descs_[i],
+                                                              top_descs_[i],
+                                                              conv_descs_[i],
+                                                              filter_desc_,
+                                                              1,
+                                                              &num_algs_bwd_filter,
+                                                              &bwdFilterPerf_[i]);
+
+                if (bwdFilterPerf_[i].memory > workspaceSizeInBytes)
+                  workspaceSizeInBytes = bwdFilterPerf_[i].memory;
+
+                int num_algs_bwd_data;
+                cudnnGetConvolutionBackwardDataAlgorithm_v7(handle_[0],
+                                                            filter_desc_,
+                                                            top_descs_[i],
+                                                            conv_descs_[i],
+                                                            bottom_descs_[i],
+                                                            1,
+                                                            &num_algs_bwd_data,
+                                                            &bwdDataPerf_[i]);
+
+                if (bwdDataPerf_[i].memory > workspaceSizeInBytes)
+                  workspaceSizeInBytes = bwdDataPerf_[i].memory;
+                cudaFree(workspaceData);
+                cudaError_t err = cudaMalloc(&workspaceData, workspaceSizeInBytes);
+                if (err != cudaSuccess)
+                  min_memory_ = true;
+              }
+            if (min_memory_)
+              {
+                fwdPerf_[i].algo = CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM;
+                fwdPerf_[i].memory = 0;
+                bwdFilterPerf_[i].algo = CUDNN_CONVOLUTION_BWD_FILTER_ALGO_0;
+                bwdFilterPerf_[i].memory = 0;
+                bwdDataPerf_[i].algo = CUDNN_CONVOLUTION_BWD_DATA_ALGO_0;
+                bwdDataPerf_[i].memory = 0;
+                workspaceData = NULL;
+              }
+          }
+#endif
       }
 
-      // NULL out all workspace pointers
-      for (int g = 0; g < (this->group_ * CUDNN_STREAMS_PER_GROUP); g++) {
-        workspace[g] = NULL;
+    // Tensor descriptor for bias.
+    if (this->bias_term_) {
+#if CUDNN_VERSION_MIN(7,0,0)
+      if (multiple_handles_)
+#endif
+        cudnn::setTensor4dDesc<Dtype>(&bias_desc_,
+                                      1, this->num_output_ / this->group_, 1, 1);
+#if CUDNN_VERSION_MIN(7,0,0)
+      else
+        cudnn::setTensor4dDesc<Dtype>(&bias_desc_,
+                                      1, this->num_output_, 1, 1);
+#endif
+    }
+  }
+
+
+
+  template <typename Dtype>
+  CuDNNConvolutionLayer<Dtype>::~CuDNNConvolutionLayer() {
+    // Check that handles have been setup before destroying.
+    if (!handles_setup_) { return; }
+
+    for (int i = 0; i < bottom_descs_.size(); i++) {
+      cudnnDestroyTensorDescriptor(bottom_descs_[i]);
+      cudnnDestroyTensorDescriptor(top_descs_[i]);
+      cudnnDestroyConvolutionDescriptor(conv_descs_[i]);
+    }
+    if (this->bias_term_) {
+      cudnnDestroyTensorDescriptor(bias_desc_);
+    }
+    cudnnDestroyFilterDescriptor(filter_desc_);
+
+    cudaFree(workspaceData);
+
+#if CUDNN_VERSION_MIN(7,0,0)
+    if (multiple_handles_)
+      {
+#endif
+        for (int g = 0; g < this->group_ * CUDNN_STREAMS_PER_GROUP; g++) {
+          cudnnDestroy(handle_[g]);
+          cudaStreamDestroy(stream_[g]);
+        }
+        delete [] stream_;
+        delete [] workspace;
+        delete [] fwd_algo_;
+        delete [] bwd_filter_algo_;
+        delete [] bwd_data_algo_;
+        delete [] workspace_fwd_sizes_;
+        delete [] workspace_bwd_data_sizes_;
+        delete [] workspace_bwd_filter_sizes_;
+#if CUDNN_VERSION_MIN(7,0,0)
       }
-      // NULL out underlying data
-      workspaceData = NULL;
-      workspaceSizeInBytes = 0;
-    }
+    else
+      {
+        fwdPerf_.clear();
+        bwdDataPerf_.clear();
+        bwdFilterPerf_.clear();
+        cudnnDestroy(handle_[0]);
+      }
+#endif
 
-    // if we succeed in the allocation, set pointer aliases for workspaces
-    for (int g = 0; g < (this->group_ * CUDNN_STREAMS_PER_GROUP); g++) {
-      workspace[g] = reinterpret_cast<char *>(workspaceData) + g*max_workspace;
-    }
+    delete [] handle_;
   }
 
-  // Tensor descriptor for bias.
-  if (this->bias_term_) {
-    cudnn::setTensor4dDesc<Dtype>(&bias_desc_,
-        1, this->num_output_ / this->group_, 1, 1);
-  }
-}
-
-template <typename Dtype>
-CuDNNConvolutionLayer<Dtype>::~CuDNNConvolutionLayer() {
-  // Check that handles have been setup before destroying.
-  if (!handles_setup_) { return; }
-
-  for (int i = 0; i < bottom_descs_.size(); i++) {
-    cudnnDestroyTensorDescriptor(bottom_descs_[i]);
-    cudnnDestroyTensorDescriptor(top_descs_[i]);
-    cudnnDestroyConvolutionDescriptor(conv_descs_[i]);
-  }
-  if (this->bias_term_) {
-    cudnnDestroyTensorDescriptor(bias_desc_);
-  }
-  cudnnDestroyFilterDescriptor(filter_desc_);
-
-  for (int g = 0; g < this->group_ * CUDNN_STREAMS_PER_GROUP; g++) {
-    CUDNN_CHECK(cudnnDestroy(handle_[g]));
-    cudaStreamDestroy(stream_[g]);
-  }
-
-  cudaFree(workspaceData);
-  delete [] workspace;
-  delete [] stream_;
-  delete [] handle_;
-  delete [] fwd_algo_;
-  delete [] bwd_filter_algo_;
-  delete [] bwd_data_algo_;
-  delete [] workspace_fwd_sizes_;
-  delete [] workspace_bwd_data_sizes_;
-  delete [] workspace_bwd_filter_sizes_;
-}
-
-INSTANTIATE_CLASS(CuDNNConvolutionLayer);
+  INSTANTIATE_CLASS(CuDNNConvolutionLayer);
 
 }   // namespace caffe
 #endif

--- a/src/caffe/layers/cudnn_conv_layer.cu
+++ b/src/caffe/layers/cudnn_conv_layer.cu
@@ -15,33 +15,61 @@ void CuDNNConvolutionLayer<Dtype>::Forward_gpu(
     const Dtype* bottom_data = bottom[i]->gpu_data();
     Dtype* top_data = top[i]->mutable_gpu_data();
 
-    // Forward through cuDNN in parallel over groups.
-    for (int g = 0; g < this->group_; g++) {
-      // Filters.
-      CUDNN_CHECK(cudnnConvolutionForward(handle_[g],
-            cudnn::dataType<Dtype>::one,
-            bottom_descs_[i], bottom_data + bottom_offset_ * g,
-            filter_desc_, weight + this->weight_offset_ * g,
-            conv_descs_[i],
-            fwd_algo_[i], workspace[g], workspace_fwd_sizes_[i],
-            cudnn::dataType<Dtype>::zero,
-            top_descs_[i], top_data + top_offset_ * g));
+#if CUDNN_VERSION_MIN(7,0,0)
+    if (multiple_handles_)
+      {
+#endif
+        // Forward through cuDNN in parallel over groups.
+        for (int g = 0; g < this->group_; g++) {
+          // Filters.
+          CUDNN_CHECK(cudnnConvolutionForward(handle_[g],
+                                              cudnn::dataType<Dtype>::one,
+                                              bottom_descs_[i], bottom_data + bottom_offset_ * g,
+                                              filter_desc_, weight + this->weight_offset_ * g,
+                                              conv_descs_[i],
+                                              fwd_algo_[i], workspace[g], workspace_fwd_sizes_[i],
+                                              cudnn::dataType<Dtype>::zero,
+                                              top_descs_[i], top_data + top_offset_ * g));
 
-      // Bias.
-      if (this->bias_term_) {
-        const Dtype* bias_data = this->blobs_[1]->gpu_data();
-        CUDNN_CHECK(cudnnAddTensor(handle_[g],
-              cudnn::dataType<Dtype>::one,
-              bias_desc_, bias_data + bias_offset_ * g,
-              cudnn::dataType<Dtype>::one,
-              top_descs_[i], top_data + top_offset_ * g));
+          // Bias.
+          if (this->bias_term_) {
+            const Dtype* bias_data = this->blobs_[1]->gpu_data();
+            CUDNN_CHECK(cudnnAddTensor(handle_[g],
+                                       cudnn::dataType<Dtype>::one,
+                                       bias_desc_, bias_data + bias_offset_ * g,
+                                       cudnn::dataType<Dtype>::one,
+                                       top_descs_[i], top_data + top_offset_ * g));
+          }
+        }
+        // Synchronize the work across groups, each of which went into its own
+        // stream, by launching an empty kernel into the default (null) stream.
+        // NOLINT_NEXT_LINE(whitespace/operators)
+        sync_conv_groups<<<1, 1>>>();
+#if CUDNN_VERSION_MIN(7,0,0)
       }
-    }
+    else
+      {
+        CUDNN_CHECK(cudnnConvolutionForward(handle_[0],
+                                            cudnn::dataType<Dtype>::one,
+                                            bottom_descs_[i], bottom_data,
+                                            filter_desc_, weight,
+                                            conv_descs_[i],
+                                            fwdPerf_[i].algo, workspaceData,
+                                            fwdPerf_[i].memory,
+                                            cudnn::dataType<Dtype>::zero,
+                                            top_descs_[i], top_data));
 
-    // Synchronize the work across groups, each of which went into its own
-    // stream, by launching an empty kernel into the default (null) stream.
-    // NOLINT_NEXT_LINE(whitespace/operators)
-    sync_conv_groups<<<1, 1>>>();
+        // Bias.
+        if (this->bias_term_) {
+          const Dtype* bias_data = this->blobs_[1]->gpu_data();
+          CUDNN_CHECK(cudnnAddTensor(handle_[0],
+                                     cudnn::dataType<Dtype>::one,
+                                     bias_desc_, bias_data,
+                                     cudnn::dataType<Dtype>::one,
+                                     top_descs_[i], top_data));
+        }
+      }
+#endif
   }
 }
 
@@ -60,55 +88,107 @@ void CuDNNConvolutionLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
   }
   for (int i = 0; i < top.size(); ++i) {
     const Dtype* top_diff = top[i]->gpu_diff();
-    // Backward through cuDNN in parallel over groups and gradients.
-    for (int g = 0; g < this->group_; g++) {
-      // Gradient w.r.t. bias.
-      if (this->bias_term_ && this->param_propagate_down_[1]) {
-        CUDNN_CHECK(cudnnConvolutionBackwardBias(handle_[0*this->group_ + g],
-              cudnn::dataType<Dtype>::one,
-              top_descs_[i],  top_diff + top_offset_ * g,
-              cudnn::dataType<Dtype>::one,
-              bias_desc_, bias_diff + bias_offset_ * g));
-      }
 
-      // Gradient w.r.t. weights.
-      if (this->param_propagate_down_[0]) {
-        const Dtype* bottom_data = bottom[i]->gpu_data();
-        CUDNN_CHECK(cudnnConvolutionBackwardFilter(
-              handle_[1*this->group_ + g],
-              cudnn::dataType<Dtype>::one,
-              bottom_descs_[i], bottom_data + bottom_offset_ * g,
-              top_descs_[i],    top_diff + top_offset_ * g,
-              conv_descs_[i],
-              bwd_filter_algo_[i], workspace[1*this->group_ + g],
-              workspace_bwd_filter_sizes_[i],
-              cudnn::dataType<Dtype>::one,
-              filter_desc_, weight_diff + this->weight_offset_ * g));
-      }
+#if CUDNN_VERSION_MIN(7,0,0)
+    if (multiple_handles_)
+      {
+#endif
+        // Backward through cuDNN in parallel over groups and gradients.
+        for (int g = 0; g < this->group_; g++) {
+          // Gradient w.r.t. bias.
+          if (this->bias_term_ && this->param_propagate_down_[1]) {
+            CUDNN_CHECK(cudnnConvolutionBackwardBias(handle_[0*this->group_ + g],
+                                                     cudnn::dataType<Dtype>::one,
+                                                     top_descs_[i],  top_diff + top_offset_ * g,
+                                                     cudnn::dataType<Dtype>::one,
+                                                     bias_desc_, bias_diff + bias_offset_ * g));
+          }
 
-      // Gradient w.r.t. bottom data.
-      if (propagate_down[i]) {
-        if (weight == NULL) {
-          weight = this->blobs_[0]->gpu_data();
+          // Gradient w.r.t. weights.
+          if (this->param_propagate_down_[0]) {
+            const Dtype* bottom_data = bottom[i]->gpu_data();
+            CUDNN_CHECK(cudnnConvolutionBackwardFilter(
+                                                       handle_[1*this->group_ + g],
+                                                       cudnn::dataType<Dtype>::one,
+                                                       bottom_descs_[i], bottom_data + bottom_offset_ * g,
+                                                       top_descs_[i],    top_diff + top_offset_ * g,
+                                                       conv_descs_[i],
+                                                       bwd_filter_algo_[i], workspace[1*this->group_ + g],
+                                                       workspace_bwd_filter_sizes_[i],
+                                                       cudnn::dataType<Dtype>::one,
+                                                       filter_desc_, weight_diff + this->weight_offset_ * g));
+          }
+
+          // Gradient w.r.t. bottom data.
+          if (propagate_down[i]) {
+            if (weight == NULL) {
+              weight = this->blobs_[0]->gpu_data();
+            }
+            Dtype* bottom_diff = bottom[i]->mutable_gpu_diff();
+            CUDNN_CHECK(cudnnConvolutionBackwardData(
+                                                     handle_[2*this->group_ + g],
+                                                     cudnn::dataType<Dtype>::one,
+                                                     filter_desc_, weight + this->weight_offset_ * g,
+                                                     top_descs_[i], top_diff + top_offset_ * g,
+                                                     conv_descs_[i],
+                                                     bwd_data_algo_[i], workspace[2*this->group_ + g],
+                                                     workspace_bwd_data_sizes_[i],
+                                                     cudnn::dataType<Dtype>::zero,
+                                                     bottom_descs_[i], bottom_diff + bottom_offset_ * g));
+          }
         }
-        Dtype* bottom_diff = bottom[i]->mutable_gpu_diff();
-        CUDNN_CHECK(cudnnConvolutionBackwardData(
-              handle_[2*this->group_ + g],
-              cudnn::dataType<Dtype>::one,
-              filter_desc_, weight + this->weight_offset_ * g,
-              top_descs_[i], top_diff + top_offset_ * g,
-              conv_descs_[i],
-              bwd_data_algo_[i], workspace[2*this->group_ + g],
-              workspace_bwd_data_sizes_[i],
-              cudnn::dataType<Dtype>::zero,
-              bottom_descs_[i], bottom_diff + bottom_offset_ * g));
-      }
-    }
 
-    // Synchronize the work across groups, each of which went into its own
-    // stream, by launching an empty kernel into the default (null) stream.
-    // NOLINT_NEXT_LINE(whitespace/operators)
-    sync_conv_groups<<<1, 1>>>();
+
+        // Synchronize the work across groups, each of which went into its own
+        // stream, by launching an empty kernel into the default (null) stream.
+        // NOLINT_NEXT_LINE(whitespace/operators)
+        sync_conv_groups<<<1, 1>>>();
+
+#if CUDNN_VERSION_MIN(7,0,0)
+      }
+    else
+      {
+          if (this->bias_term_ && this->param_propagate_down_[1]) {
+            CUDNN_CHECK(cudnnConvolutionBackwardBias(handle_[0],
+                                                     cudnn::dataType<Dtype>::one,
+                                                     top_descs_[i],  top_diff,
+                                                     cudnn::dataType<Dtype>::one,
+                                                     bias_desc_, bias_diff));
+          }
+
+          // Gradient w.r.t. weights.
+          if (this->param_propagate_down_[0]) {
+            const Dtype* bottom_data = bottom[i]->gpu_data();
+            CUDNN_CHECK(cudnnConvolutionBackwardFilter(handle_[0],
+                                                       cudnn::dataType<Dtype>::one,
+                                                       bottom_descs_[i], bottom_data,
+                                                       top_descs_[i],    top_diff,
+                                                       conv_descs_[i],
+                                                       bwdFilterPerf_[i].algo, workspaceData,
+                                                       bwdFilterPerf_[i].memory,
+                                                       cudnn::dataType<Dtype>::one,
+                                                       filter_desc_, weight_diff));
+          }
+
+          // Gradient w.r.t. bottom data.
+          if (propagate_down[i]) {
+            if (weight == NULL) {
+              weight = this->blobs_[0]->gpu_data();
+            }
+            Dtype* bottom_diff = bottom[i]->mutable_gpu_diff();
+
+            CUDNN_CHECK(cudnnConvolutionBackwardData(handle_[0],
+                                                     cudnn::dataType<Dtype>::one,
+                                                     filter_desc_, weight,
+                                                     top_descs_[i], top_diff,
+                                                     conv_descs_[i],
+                                                     bwdDataPerf_[i].algo, workspaceData,
+                                                     bwdDataPerf_[i].memory,
+                                                     cudnn::dataType<Dtype>::zero,
+                                                     bottom_descs_[i], bottom_diff));
+          }
+      }
+#endif
   }
 }
 

--- a/src/caffe/layers/cudnn_deconv_layer.cpp
+++ b/src/caffe/layers/cudnn_deconv_layer.cpp
@@ -18,55 +18,85 @@ template <typename Dtype>
 void CuDNNDeconvolutionLayer<Dtype>::LayerSetUp(
     const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
   DeconvolutionLayer<Dtype>::LayerSetUp(bottom, top);
-  // Initialize CUDA streams and cuDNN.
-  stream_         = new cudaStream_t[this->group_ * CUDNN_STREAMS_PER_GROUP];
-  handle_         = new cudnnHandle_t[this->group_ * CUDNN_STREAMS_PER_GROUP];
 
-  // Initialize algorithm arrays
-  fwd_algo_       = new cudnnConvolutionFwdAlgo_t[bottom.size()];
-  bwd_filter_algo_= new cudnnConvolutionBwdFilterAlgo_t[bottom.size()];
-  bwd_data_algo_  = new cudnnConvolutionBwdDataAlgo_t[bottom.size()];
-
-  // initialize size arrays
-  workspace_fwd_sizes_ = new size_t[bottom.size()];
-  workspace_bwd_filter_sizes_ = new size_t[bottom.size()];
-  workspace_bwd_data_sizes_ = new size_t[bottom.size()];
-
-  // workspace data
   workspaceSizeInBytes = 0;
   workspaceData = NULL;
-  workspace = new void*[this->group_ * CUDNN_STREAMS_PER_GROUP];
 
-  for (size_t i = 0; i < bottom.size(); ++i) {
-    // initialize all to default algorithms
-    fwd_algo_[i] = (cudnnConvolutionFwdAlgo_t)0;
-    bwd_filter_algo_[i] = (cudnnConvolutionBwdFilterAlgo_t)0;
-    bwd_data_algo_[i] = (cudnnConvolutionBwdDataAlgo_t)0;
-    // default algorithms don't require workspace
-    workspace_fwd_sizes_[i] = 0;
-    workspace_bwd_data_sizes_[i] = 0;
-    workspace_bwd_filter_sizes_[i] = 0;
-  }
+#if CUDNN_VERSION_MIN(7,0,0)
+  if (multiple_handles_)
+    {
+#endif
+      // Initialize CUDA streams and cuDNN.
+      stream_         = new cudaStream_t[this->group_ * CUDNN_STREAMS_PER_GROUP];
+      handle_         = new cudnnHandle_t[this->group_ * CUDNN_STREAMS_PER_GROUP];
 
-  for (int g = 0; g < this->group_ * CUDNN_STREAMS_PER_GROUP; g++) {
-    CAFFE1_CUDA_CHECK(cudaStreamCreate(&stream_[g]));
-    CUDNN_CHECK(cudnnCreate(&handle_[g]));
-    CUDNN_CHECK(cudnnSetStream(handle_[g], stream_[g]));
-    workspace[g] = NULL;
-  }
+      // Initialize algorithm arrays
+      fwd_algo_       = new cudnnConvolutionFwdAlgo_t[bottom.size()];
+      bwd_filter_algo_= new cudnnConvolutionBwdFilterAlgo_t[bottom.size()];
+      bwd_data_algo_  = new cudnnConvolutionBwdDataAlgo_t[bottom.size()];
 
-  // Set the indexing parameters.
-  bias_offset_ = (this->num_output_ / this->group_);
+      // initialize size arrays
+      workspace_fwd_sizes_ = new size_t[bottom.size()];
+      workspace_bwd_filter_sizes_ = new size_t[bottom.size()];
+      workspace_bwd_data_sizes_ = new size_t[bottom.size()];
+
+      // workspace data
+      workspace = new void*[this->group_ * CUDNN_STREAMS_PER_GROUP];
+
+      for (size_t i = 0; i < bottom.size(); ++i) {
+        // initialize all to default algorithms
+        fwd_algo_[i] = (cudnnConvolutionFwdAlgo_t)0;
+        bwd_filter_algo_[i] = (cudnnConvolutionBwdFilterAlgo_t)0;
+        bwd_data_algo_[i] = (cudnnConvolutionBwdDataAlgo_t)0;
+        // default algorithms don't require workspace
+        workspace_fwd_sizes_[i] = 0;
+        workspace_bwd_data_sizes_[i] = 0;
+        workspace_bwd_filter_sizes_[i] = 0;
+      }
+
+      for (int g = 0; g < this->group_ * CUDNN_STREAMS_PER_GROUP; g++) {
+        CAFFE1_CUDA_CHECK(cudaStreamCreate(&stream_[g]));
+        CUDNN_CHECK(cudnnCreate(&handle_[g]));
+        CUDNN_CHECK(cudnnSetStream(handle_[g], stream_[g]));
+        workspace[g] = NULL;
+      }
+
+      // Set the indexing parameters.
+      bias_offset_ = (this->num_output_ / this->group_);
+
+#if CUDNN_VERSION_MIN(7,0,0)
+    }
+  else
+    {
+      handle_         = new cudnnHandle_t[1];
+      fwdPerf_.resize(bottom.size());
+      bwdFilterPerf_.resize(bottom.size());
+      bwdDataPerf_.resize(bottom.size());
+      CUDNN_CHECK(cudnnCreate(&handle_[0]));
+    }
+#endif
+
 
   // Create filter descriptor.
   const int* kernel_shape_data = this->kernel_shape_.cpu_data();
   const int kernel_h = kernel_shape_data[0];
   const int kernel_w = kernel_shape_data[1];
-  cudnn::createFilterDesc<Dtype>(&filter_desc_,
-                                 this->channels_ / this->group_,
-                                 this->num_output_ / this->group_,
-                                 kernel_h,
-                                 kernel_w);
+
+#if CUDNN_VERSION_MIN(7,0,0)
+  if (multiple_handles_)
+#endif
+    cudnn::createFilterDesc<Dtype>(&filter_desc_,
+                                   this->channels_ / this->group_,
+                                   this->num_output_ / this->group_,
+                                   kernel_h,
+                                   kernel_w);
+#if CUDNN_VERSION_MIN(7,0,0)
+  else
+    // GUILLO : if cudnn problems, that may likely be that the third argument should be divided by group, and not the second (hard to tell offline as everything is reversed)
+    cudnn::createFilterDesc<Dtype>(&filter_desc_, this->channels_ / this->group_, this->num_output_,
+                                   kernel_h, kernel_w);
+#endif
+
 
   // Create tensor descriptor(s) for data and corresponding convolution(s).
   for (int i = 0; i < bottom.size(); i++) {
@@ -97,8 +127,16 @@ void CuDNNDeconvolutionLayer<Dtype>::Reshape(
       << "CuDNNDeconvolutionLayer input must have 2 spatial axes "
       << "(e.g., height and width). "
       << "Use 'engine: CAFFE' for general ND convolution.";
-  bottom_offset_ = this->bottom_dim_ / this->group_;
-  top_offset_ = this->top_dim_ / this->group_;
+#if CUDNN_VERSION_MIN(7,0,0)
+  if (multiple_handles_)
+    {
+#endif
+      bottom_offset_ = this->bottom_dim_ / this->group_;
+      top_offset_ = this->top_dim_ / this->group_;
+#if CUDNN_VERSION_MIN(7,0,0)
+    }
+#endif
+
   const int height = bottom[0]->shape(this->channel_axis_ + 1);
   const int width = bottom[0]->shape(this->channel_axis_ + 2);
   const int height_out = top[0]->shape(this->channel_axis_ + 1);
@@ -112,180 +150,282 @@ void CuDNNDeconvolutionLayer<Dtype>::Reshape(
 
   // Specify workspace limit for kernels directly until we have a
   // planning strategy and a rewrite of Caffe's GPU memory mangagement
-  size_t workspace_limit_bytes = 8*1024*1024;
 
   for (int i = 0; i < bottom.size(); i++) {
-    cudnn::setTensor4dDesc<Dtype>(&bottom_descs_[i],
-                                  this->num_,
-                                  this->channels_ / this->group_,
-                                  height,
-                                  width,
-                                  this->channels_ * height * width,
-                                  height * width,
-                                  width,
-                                  1);
-    cudnn::setTensor4dDesc<Dtype>(&top_descs_[i],
-                                  this->num_,
-                                  this->num_output_ / this->group_,
-                                  height_out,
-                                  width_out,
-                                  this->num_output_ * height_out * width_out,
-                                  height_out * width_out,
-                                  width_out,
-                                  1);
-    cudnn::setConvolutionDesc<Dtype>(&conv_descs_[i],
-                                     top_descs_[i],
-                                     filter_desc_,
-                                     pad_h,
-                                     pad_w,
-                                     stride_h,
-                                     stride_w);
+#if CUDNN_VERSION_MIN(7,0,0)
+    if (multiple_handles_)
+      {
+#endif
+        size_t workspace_limit_bytes = 8*1024*1024;
+        cudnn::setTensor4dDesc<Dtype>(&bottom_descs_[i],
+                                      this->num_,
+                                      this->channels_ / this->group_,
+                                      height,
+                                      width,
+                                      this->channels_ * height * width,
+                                      height * width,
+                                      width,
+                                      1);
+        cudnn::setTensor4dDesc<Dtype>(&top_descs_[i],
+                                      this->num_,
+                                      this->num_output_ / this->group_,
+                                      height_out,
+                                      width_out,
+                                      this->num_output_ * height_out * width_out,
+                                      height_out * width_out,
+                                      width_out,
+                                      1);
+        cudnn::setConvolutionDesc<Dtype>(&conv_descs_[i],
+                                         top_descs_[i],
+                                         filter_desc_,
+                                         pad_h,
+                                         pad_w,
+                                         stride_h,
+                                         stride_w);
 
-    // choose forward and backward algorithms + workspace(s)
-    CUDNN_CHECK(cudnnGetConvolutionForwardAlgorithm(
-        handle_[0],
-        top_descs_[i],
-        filter_desc_,
-        conv_descs_[i],
-        bottom_descs_[i],
-        CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT,
-        workspace_limit_bytes,
-        &fwd_algo_[i]));
+        // choose forward and backward algorithms + workspace(s)
+        CUDNN_CHECK(cudnnGetConvolutionForwardAlgorithm(
+                                                        handle_[0],
+                                                        top_descs_[i],
+                                                        filter_desc_,
+                                                        conv_descs_[i],
+                                                        bottom_descs_[i],
+                                                        CUDNN_CONVOLUTION_FWD_SPECIFY_WORKSPACE_LIMIT,
+                                                        workspace_limit_bytes,
+                                                        &fwd_algo_[i]));
 
-    // We have found that CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM is
-    // buggy. Thus, if this algo was chosen, choose winograd instead. If
-    // winograd is not supported or workspace is larger than threshold, choose
-    // implicit_gemm instead.
-    if (fwd_algo_[i] == CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM) {
-      size_t winograd_workspace_size;
-      cudnnStatus_t status = cudnnGetConvolutionForwardWorkspaceSize(
-          handle_[0],
-          top_descs_[i],
-          filter_desc_,
-          conv_descs_[i],
-          bottom_descs_[i],
-          CUDNN_CONVOLUTION_FWD_ALGO_WINOGRAD,
-          &winograd_workspace_size);
-      if (status != CUDNN_STATUS_SUCCESS ||
-          winograd_workspace_size >= workspace_limit_bytes) {
-        fwd_algo_[i] = CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM;
-      } else {
-        fwd_algo_[i] = CUDNN_CONVOLUTION_FWD_ALGO_WINOGRAD;
+        // We have found that CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM is
+        // buggy. Thus, if this algo was chosen, choose winograd instead. If
+        // winograd is not supported or workspace is larger than threshold, choose
+        // implicit_gemm instead.
+        if (fwd_algo_[i] == CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_PRECOMP_GEMM) {
+          size_t winograd_workspace_size;
+          cudnnStatus_t status = cudnnGetConvolutionForwardWorkspaceSize(
+                                                                         handle_[0],
+                                                                         top_descs_[i],
+                                                                         filter_desc_,
+                                                                         conv_descs_[i],
+                                                                         bottom_descs_[i],
+                                                                         CUDNN_CONVOLUTION_FWD_ALGO_WINOGRAD,
+                                                                         &winograd_workspace_size);
+          if (status != CUDNN_STATUS_SUCCESS ||
+              winograd_workspace_size >= workspace_limit_bytes) {
+            fwd_algo_[i] = CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM;
+          } else {
+            fwd_algo_[i] = CUDNN_CONVOLUTION_FWD_ALGO_WINOGRAD;
+          }
+        }
+
+        CUDNN_CHECK(cudnnGetConvolutionForwardWorkspaceSize(
+                                                            handle_[0],
+                                                            top_descs_[i],
+                                                            filter_desc_,
+                                                            conv_descs_[i],
+                                                            bottom_descs_[i],
+                                                            fwd_algo_[i],
+                                                            &(workspace_fwd_sizes_[i])));
+
+        // choose backward algorithm for filter
+        CUDNN_CHECK(cudnnGetConvolutionBackwardFilterAlgorithm(
+                                                               handle_[0],
+                                                               top_descs_[i],
+                                                               bottom_descs_[i],
+                                                               conv_descs_[i],
+                                                               filter_desc_,
+                                                               CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT,
+                                                               workspace_limit_bytes,
+                                                               &bwd_filter_algo_[i]));
+
+        // get workspace for backwards filter algorithm
+        CUDNN_CHECK(cudnnGetConvolutionBackwardFilterWorkspaceSize(
+                                                                   handle_[0],
+                                                                   top_descs_[i],
+                                                                   bottom_descs_[i],
+                                                                   conv_descs_[i],
+                                                                   filter_desc_,
+                                                                   bwd_filter_algo_[i],
+                                                                   &workspace_bwd_filter_sizes_[i]));
+
+        // choose backward algo for data
+        CUDNN_CHECK(cudnnGetConvolutionBackwardDataAlgorithm(
+                                                             handle_[0],
+                                                             filter_desc_,
+                                                             bottom_descs_[i],
+                                                             conv_descs_[i],
+                                                             top_descs_[i],
+                                                             CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT,
+                                                             workspace_limit_bytes,
+                                                             &bwd_data_algo_[i]));
+
+        // get workspace size
+        CUDNN_CHECK(cudnnGetConvolutionBackwardDataWorkspaceSize(
+                                                                 handle_[0],
+                                                                 filter_desc_,
+                                                                 bottom_descs_[i],
+                                                                 conv_descs_[i],
+                                                                 top_descs_[i],
+                                                                 bwd_data_algo_[i],
+                                                                 &workspace_bwd_data_sizes_[i]));
+
+        // reduce over all workspace sizes to get a maximum to allocate / reallocate
+        size_t total_workspace_fwd = 0;
+        size_t total_workspace_bwd_data = 0;
+        size_t total_workspace_bwd_filter = 0;
+
+        for (size_t i = 0; i < bottom.size(); i++) {
+          total_workspace_fwd        = std::max(total_workspace_fwd,
+                                                workspace_fwd_sizes_[i]);
+          total_workspace_bwd_data   = std::max(total_workspace_bwd_data,
+                                                workspace_bwd_data_sizes_[i]);
+          total_workspace_bwd_filter = std::max(total_workspace_bwd_filter,
+                                                workspace_bwd_filter_sizes_[i]);
+        }
+        // get max over all operations
+        size_t max_workspace = std::max(total_workspace_fwd,
+                                        total_workspace_bwd_data);
+        max_workspace = std::max(max_workspace, total_workspace_bwd_filter);
+        // ensure all groups have enough workspace
+        size_t total_max_workspace = max_workspace *
+          (this->group_ * CUDNN_STREAMS_PER_GROUP);
+
+        // this is the total amount of storage needed over all groups + streams
+        if (total_max_workspace > workspaceSizeInBytes) {
+          DLOG(INFO) << "Reallocating workspace storage: " << total_max_workspace;
+          workspaceSizeInBytes = total_max_workspace;
+
+          // free the existing workspace and allocate a new (larger) one
+          cudaFree(this->workspaceData);
+
+          cudaError_t err = cudaMalloc(&(this->workspaceData), workspaceSizeInBytes);
+          if (err != cudaSuccess) {
+            // force zero memory path
+            for (int i = 0; i < bottom.size(); i++) {
+              workspace_fwd_sizes_[i] = 0;
+              workspace_bwd_filter_sizes_[i] = 0;
+              workspace_bwd_data_sizes_[i] = 0;
+              fwd_algo_[i] = CUDNN_CONVOLUTION_FWD_ALGO_FFT_TILING;
+              bwd_filter_algo_[i] = CUDNN_CONVOLUTION_BWD_FILTER_ALGO_0;
+              bwd_data_algo_[i] = CUDNN_CONVOLUTION_BWD_DATA_ALGO_0;
+            }
+
+            // NULL out all workspace pointers
+            for (int g = 0; g < (this->group_ * CUDNN_STREAMS_PER_GROUP); g++) {
+              workspace[g] = NULL;
+            }
+            // NULL out underlying data
+            workspaceData = NULL;
+            workspaceSizeInBytes = 0;
+          }
+
+          // if we succeed in the allocation, set pointer aliases for workspaces
+          for (int g = 0; g < (this->group_ * CUDNN_STREAMS_PER_GROUP); g++) {
+            workspace[g] = reinterpret_cast<char *>(workspaceData) + g*max_workspace;
+          }
+        }
+#if CUDNN_VERSION_MIN(7,0,0)
       }
-    }
+    else
+      {
+        cudnn::setTensor4dDesc<Dtype>(&bottom_descs_[i],
+                                      this->num_,
+                                      this->channels_,
+                                      height,
+                                      width,
+                                      this->channels_ * height * width,
+                                      height * width,
+                                      width,
+                                      1);
+        cudnn::setTensor4dDesc<Dtype>(&top_descs_[i],
+                                      this->num_,
+                                      this->num_output_,
+                                      height_out,
+                                      width_out,
+                                      this->num_output_ * height_out * width_out,
+                                      height_out * width_out,
+                                      width_out,
+                                      1);
+        cudnn::setConvolutionDesc<Dtype>(&conv_descs_[i],
+                                         top_descs_[i],
+                                         filter_desc_,
+                                         pad_h,
+                                         pad_w,
+                                         stride_h,
+                                         stride_w);
+        cudnnSetConvolutionGroupCount(conv_descs_[i], this->group_);
 
-    CUDNN_CHECK(cudnnGetConvolutionForwardWorkspaceSize(
-        handle_[0],
-        top_descs_[i],
-        filter_desc_,
-        conv_descs_[i],
-        bottom_descs_[i],
-        fwd_algo_[i],
-        &(workspace_fwd_sizes_[i])));
 
-    // choose backward algorithm for filter
-    CUDNN_CHECK(cudnnGetConvolutionBackwardFilterAlgorithm(
-        handle_[0],
-        top_descs_[i],
-        bottom_descs_[i],
-        conv_descs_[i],
-        filter_desc_,
-        CUDNN_CONVOLUTION_BWD_FILTER_SPECIFY_WORKSPACE_LIMIT,
-        workspace_limit_bytes,
-        &bwd_filter_algo_[i]));
+        int num_algs_fwd;
+        cudnnGetConvolutionForwardAlgorithm_v7(handle_[0],
+                                               top_descs_[i],
+                                               filter_desc_,
+                                               conv_descs_[i],
+                                               bottom_descs_[i],
+                                               1,
+                                               &num_algs_fwd,
+                                               &fwdPerf_[i]);
+        if (fwdPerf_[i].memory > workspaceSizeInBytes)
+          workspaceSizeInBytes = fwdPerf_[i].memory;
 
-    // get workspace for backwards filter algorithm
-    CUDNN_CHECK(cudnnGetConvolutionBackwardFilterWorkspaceSize(
-        handle_[0],
-        top_descs_[i],
-        bottom_descs_[i],
-        conv_descs_[i],
-        filter_desc_,
-        bwd_filter_algo_[i],
-        &workspace_bwd_filter_sizes_[i]));
+        cudnnSetConvolutionMathType(conv_descs_[i],fwdPerf_[i].mathType);
 
-    // choose backward algo for data
-    CUDNN_CHECK(cudnnGetConvolutionBackwardDataAlgorithm(
-        handle_[0],
-        filter_desc_,
-        bottom_descs_[i],
-        conv_descs_[i],
-        top_descs_[i],
-        CUDNN_CONVOLUTION_BWD_DATA_SPECIFY_WORKSPACE_LIMIT,
-        workspace_limit_bytes,
-        &bwd_data_algo_[i]));
+        if (!min_memory_)
+          {
+            int num_algs_bwd_filter;
+            cudnnGetConvolutionBackwardFilterAlgorithm_v7(handle_[0],
+                                                          top_descs_[i],
+                                                          bottom_descs_[i],
+                                                          conv_descs_[i],
+                                                          filter_desc_,
+                                                          1,
+                                                          &num_algs_bwd_filter,
+                                                          &bwdFilterPerf_[i]);
 
-    // get workspace size
-    CUDNN_CHECK(cudnnGetConvolutionBackwardDataWorkspaceSize(
-        handle_[0],
-        filter_desc_,
-        bottom_descs_[i],
-        conv_descs_[i],
-        top_descs_[i],
-        bwd_data_algo_[i],
-        &workspace_bwd_data_sizes_[i]));
-  }
+            if (bwdFilterPerf_[i].memory > workspaceSizeInBytes)
+              workspaceSizeInBytes = bwdFilterPerf_[i].memory;
 
-  // reduce over all workspace sizes to get a maximum to allocate / reallocate
-  size_t total_workspace_fwd = 0;
-  size_t total_workspace_bwd_data = 0;
-  size_t total_workspace_bwd_filter = 0;
+            int num_algs_bwd_data;
+            cudnnGetConvolutionBackwardDataAlgorithm_v7(handle_[0],
+                                                        filter_desc_,
+                                                        bottom_descs_[i],
+                                                        conv_descs_[i],
+                                                        top_descs_[i],
+                                                        1,
+                                                        &num_algs_bwd_data,
+                                                        &bwdDataPerf_[i]);
 
-  for (size_t i = 0; i < bottom.size(); i++) {
-    total_workspace_fwd        = std::max(total_workspace_fwd,
-                                     workspace_fwd_sizes_[i]);
-    total_workspace_bwd_data   = std::max(total_workspace_bwd_data,
-                                     workspace_bwd_data_sizes_[i]);
-    total_workspace_bwd_filter = std::max(total_workspace_bwd_filter,
-                                     workspace_bwd_filter_sizes_[i]);
-  }
-  // get max over all operations
-  size_t max_workspace = std::max(total_workspace_fwd,
-                             total_workspace_bwd_data);
-  max_workspace = std::max(max_workspace, total_workspace_bwd_filter);
-  // ensure all groups have enough workspace
-  size_t total_max_workspace = max_workspace *
-                               (this->group_ * CUDNN_STREAMS_PER_GROUP);
-
-  // this is the total amount of storage needed over all groups + streams
-  if (total_max_workspace > workspaceSizeInBytes) {
-    DLOG(INFO) << "Reallocating workspace storage: " << total_max_workspace;
-    workspaceSizeInBytes = total_max_workspace;
-
-    // free the existing workspace and allocate a new (larger) one
-    cudaFree(this->workspaceData);
-
-    cudaError_t err = cudaMalloc(&(this->workspaceData), workspaceSizeInBytes);
-    if (err != cudaSuccess) {
-      // force zero memory path
-      for (int i = 0; i < bottom.size(); i++) {
-        workspace_fwd_sizes_[i] = 0;
-        workspace_bwd_filter_sizes_[i] = 0;
-        workspace_bwd_data_sizes_[i] = 0;
-        fwd_algo_[i] = CUDNN_CONVOLUTION_FWD_ALGO_FFT_TILING;
-        bwd_filter_algo_[i] = CUDNN_CONVOLUTION_BWD_FILTER_ALGO_0;
-        bwd_data_algo_[i] = CUDNN_CONVOLUTION_BWD_DATA_ALGO_0;
+            if (bwdDataPerf_[i].memory > workspaceSizeInBytes)
+              workspaceSizeInBytes = bwdDataPerf_[i].memory;
+            cudaFree(workspaceData);
+            cudaError_t err = cudaMalloc(&workspaceData, workspaceSizeInBytes);
+            if (err != cudaSuccess)
+              min_memory_ = true;
+          }
+        if (min_memory_)
+          {
+            fwdPerf_[i].algo = CUDNN_CONVOLUTION_FWD_ALGO_IMPLICIT_GEMM;
+            fwdPerf_[i].memory = 0;
+            bwdFilterPerf_[i].algo = CUDNN_CONVOLUTION_BWD_FILTER_ALGO_0;
+            bwdFilterPerf_[i].memory = 0;
+            bwdDataPerf_[i].algo = CUDNN_CONVOLUTION_BWD_DATA_ALGO_0;
+            bwdDataPerf_[i].memory = 0;
+            workspaceData = NULL;
+          }
       }
-
-      // NULL out all workspace pointers
-      for (int g = 0; g < (this->group_ * CUDNN_STREAMS_PER_GROUP); g++) {
-        workspace[g] = NULL;
-      }
-      // NULL out underlying data
-      workspaceData = NULL;
-      workspaceSizeInBytes = 0;
-    }
-
-    // if we succeed in the allocation, set pointer aliases for workspaces
-    for (int g = 0; g < (this->group_ * CUDNN_STREAMS_PER_GROUP); g++) {
-      workspace[g] = reinterpret_cast<char *>(workspaceData) + g*max_workspace;
-    }
+#endif
   }
-
   // Tensor descriptor for bias.
   if (this->bias_term_) {
-    cudnn::setTensor4dDesc<Dtype>(
-        &bias_desc_, 1, this->num_output_ / this->group_, 1, 1);
+#if CUDNN_VERSION_MIN(7,0,0)
+    if (multiple_handles_)
+#endif
+      cudnn::setTensor4dDesc<Dtype>(
+                                    &bias_desc_, 1, this->num_output_ / this->group_, 1, 1);
+#if CUDNN_VERSION_MIN(7,0,0)
+    else
+      cudnn::setTensor4dDesc<Dtype>(&bias_desc_,
+                                    1, this->num_output_, 1, 1);
+#endif
+
   }
 }
 
@@ -304,21 +444,38 @@ CuDNNDeconvolutionLayer<Dtype>::~CuDNNDeconvolutionLayer() {
   }
   cudnnDestroyFilterDescriptor(filter_desc_);
 
-  for (int g = 0; g < this->group_ * CUDNN_STREAMS_PER_GROUP; g++) {
-    cudaStreamDestroy(stream_[g]);
-    cudnnDestroy(handle_[g]);
-  }
-
   cudaFree(workspaceData);
-  delete [] workspace;
-  delete [] stream_;
+
+
+#if CUDNN_VERSION_MIN(7,0,0)
+  if (multiple_handles_)
+    {
+#endif
+      for (int g = 0; g < this->group_ * CUDNN_STREAMS_PER_GROUP; g++) {
+        cudaStreamDestroy(stream_[g]);
+        cudnnDestroy(handle_[g]);
+      }
+      delete [] stream_;
+      delete [] workspace;
+      delete [] fwd_algo_;
+      delete [] bwd_filter_algo_;
+      delete [] bwd_data_algo_;
+      delete [] workspace_fwd_sizes_;
+      delete [] workspace_bwd_data_sizes_;
+      delete [] workspace_bwd_filter_sizes_;
+#if CUDNN_VERSION_MIN(7,0,0)
+    }
+  else
+    {
+      fwdPerf_.clear();
+      bwdDataPerf_.clear();
+      bwdFilterPerf_.clear();
+      cudnnDestroy(handle_[0]);
+    }
+#endif
+
   delete [] handle_;
-  delete [] fwd_algo_;
-  delete [] bwd_filter_algo_;
-  delete [] bwd_data_algo_;
-  delete [] workspace_fwd_sizes_;
-  delete [] workspace_bwd_data_sizes_;
-  delete [] workspace_bwd_filter_sizes_;
+
 }
 
 INSTANTIATE_CLASS(CuDNNDeconvolutionLayer);

--- a/src/caffe/layers/cudnn_deconv_layer.cu
+++ b/src/caffe/layers/cudnn_deconv_layer.cu
@@ -15,41 +15,78 @@ void CuDNNDeconvolutionLayer<Dtype>::Forward_gpu(
     const Dtype* bottom_data = bottom[i]->gpu_data();
     Dtype* top_data = top[i]->mutable_gpu_data();
 
-    // Forward through cuDNN in parallel over groups.
-    for (int g = 0; g < this->group_; g++) {
-      // Filters.
-      CUDNN_CHECK(cudnnConvolutionBackwardData(
-          handle_[g],
-          cudnn::dataType<Dtype>::one,
-          filter_desc_,
-          weight + this->weight_offset_ * g,
-          bottom_descs_[i],
-          bottom_data + bottom_offset_ * g,
-          conv_descs_[i],
-          bwd_data_algo_[i],
-          workspace[g],
-          workspace_bwd_data_sizes_[i],
-          cudnn::dataType<Dtype>::zero,
-          top_descs_[i],
-          top_data + top_offset_ * g));
+#if CUDNN_VERSION_MIN(7,0,0)
+    if (multiple_handles_)
+      {
+#endif
 
-      // Bias.
-      if (this->bias_term_) {
-        const Dtype* bias_data = this->blobs_[1]->gpu_data();
-        CUDNN_CHECK(cudnnAddTensor(handle_[g],
-                                   cudnn::dataType<Dtype>::one,
-                                   bias_desc_,
-                                   bias_data + bias_offset_ * g,
-                                   cudnn::dataType<Dtype>::one,
-                                   top_descs_[i],
-                                   top_data + top_offset_ * g));
+        // Forward through cuDNN in parallel over groups.
+        for (int g = 0; g < this->group_; g++) {
+          // Filters.
+          CUDNN_CHECK(cudnnConvolutionBackwardData(
+                                                   handle_[g],
+                                                   cudnn::dataType<Dtype>::one,
+                                                   filter_desc_,
+                                                   weight + this->weight_offset_ * g,
+                                                   bottom_descs_[i],
+                                                   bottom_data + bottom_offset_ * g,
+                                                   conv_descs_[i],
+                                                   bwd_data_algo_[i],
+                                                   workspace[g],
+                                                   workspace_bwd_data_sizes_[i],
+                                                   cudnn::dataType<Dtype>::zero,
+                                                   top_descs_[i],
+                                                   top_data + top_offset_ * g));
+
+          // Bias.
+          if (this->bias_term_) {
+            const Dtype* bias_data = this->blobs_[1]->gpu_data();
+            CUDNN_CHECK(cudnnAddTensor(handle_[g],
+                                       cudnn::dataType<Dtype>::one,
+                                       bias_desc_,
+                                       bias_data + bias_offset_ * g,
+                                       cudnn::dataType<Dtype>::one,
+                                       top_descs_[i],
+                                       top_data + top_offset_ * g));
+          }
+        }
+
+        // Synchronize the work across groups, each of which went into its own
+        // stream, by launching an empty kernel into the default (null) stream.
+        // NOLINT_NEXT_LINE(whitespace/operators)
+        sync_deconv_groups<<<1, 1>>>();
+#if CUDNN_VERSION_MIN(7,0,0)
       }
-    }
+    else
+      {
+        CUDNN_CHECK(cudnnConvolutionBackwardData(
+                                                 handle_[0],
+                                                 cudnn::dataType<Dtype>::one,
+                                                 filter_desc_,
+                                                 weight,
+                                                 bottom_descs_[i],
+                                                 bottom_data,
+                                                 conv_descs_[i],
+                                                 bwdDataPerf_[i].algo,
+                                                 workspaceData,
+                                                 bwdDataPerf_[i].memory,
+                                                 cudnn::dataType<Dtype>::zero,
+                                                 top_descs_[i],
+                                                 top_data));
 
-    // Synchronize the work across groups, each of which went into its own
-    // stream, by launching an empty kernel into the default (null) stream.
-    // NOLINT_NEXT_LINE(whitespace/operators)
-    sync_deconv_groups<<<1, 1>>>();
+        // Bias.
+        if (this->bias_term_) {
+          const Dtype* bias_data = this->blobs_[1]->gpu_data();
+          CUDNN_CHECK(cudnnAddTensor(handle_[0],
+                                     cudnn::dataType<Dtype>::one,
+                                     bias_desc_,
+                                     bias_data,
+                                     cudnn::dataType<Dtype>::one,
+                                     top_descs_[i],
+                                     top_data));
+        }
+      }
+#endif
   }
 }
 
@@ -71,64 +108,126 @@ void CuDNNDeconvolutionLayer<Dtype>::Backward_gpu(
   for (int i = 0; i < top.size(); ++i) {
     const Dtype* top_diff = top[i]->gpu_diff();
     // Backward through cuDNN in parallel over groups and gradients.
-    for (int g = 0; g < this->group_; g++) {
-      // Gradient w.r.t. bias.
-      if (this->bias_term_ && this->param_propagate_down_[1]) {
-        CUDNN_CHECK(cudnnConvolutionBackwardBias(handle_[0 * this->group_ + g],
-                                                 cudnn::dataType<Dtype>::one,
-                                                 top_descs_[i],
-                                                 top_diff + top_offset_ * g,
-                                                 cudnn::dataType<Dtype>::one,
-                                                 bias_desc_,
-                                                 bias_diff + bias_offset_ * g));
-      }
 
-      // Gradient w.r.t. weights.
-      if (this->param_propagate_down_[0]) {
-        const Dtype* bottom_data = bottom[i]->gpu_data();
-        CUDNN_CHECK(cudnnConvolutionBackwardFilter(
-            handle_[1 * this->group_ + g],
-            cudnn::dataType<Dtype>::one,
-            top_descs_[i],
-            top_diff + top_offset_ * g,
-            bottom_descs_[i],
-            bottom_data + bottom_offset_ * g,
-            conv_descs_[i],
-            bwd_filter_algo_[i],
-            workspace[1 * this->group_ + g],
-            workspace_bwd_filter_sizes_[i],
-            cudnn::dataType<Dtype>::one,
-            filter_desc_,
-            weight_diff + this->weight_offset_ * g));
-      }
 
-      // Gradient w.r.t. bottom data.
-      if (propagate_down[i]) {
-        if (weight == NULL) {
-          weight = this->blobs_[0]->gpu_data();
+#if CUDNN_VERSION_MIN(7,0,0)
+    if (multiple_handles_)
+      {
+#endif
+
+        for (int g = 0; g < this->group_; g++) {
+          // Gradient w.r.t. bias.
+          if (this->bias_term_ && this->param_propagate_down_[1]) {
+            CUDNN_CHECK(cudnnConvolutionBackwardBias(handle_[0 * this->group_ + g],
+                                                     cudnn::dataType<Dtype>::one,
+                                                     top_descs_[i],
+                                                     top_diff + top_offset_ * g,
+                                                     cudnn::dataType<Dtype>::one,
+                                                     bias_desc_,
+                                                     bias_diff + bias_offset_ * g));
+          }
+
+          // Gradient w.r.t. weights.
+          if (this->param_propagate_down_[0]) {
+            const Dtype* bottom_data = bottom[i]->gpu_data();
+            CUDNN_CHECK(cudnnConvolutionBackwardFilter(
+                                                       handle_[1 * this->group_ + g],
+                                                       cudnn::dataType<Dtype>::one,
+                                                       top_descs_[i],
+                                                       top_diff + top_offset_ * g,
+                                                       bottom_descs_[i],
+                                                       bottom_data + bottom_offset_ * g,
+                                                       conv_descs_[i],
+                                                       bwd_filter_algo_[i],
+                                                       workspace[1 * this->group_ + g],
+                                                       workspace_bwd_filter_sizes_[i],
+                                                       cudnn::dataType<Dtype>::one,
+                                                       filter_desc_,
+                                                       weight_diff + this->weight_offset_ * g));
+          }
+
+          // Gradient w.r.t. bottom data.
+          if (propagate_down[i]) {
+            if (weight == NULL) {
+              weight = this->blobs_[0]->gpu_data();
+            }
+            Dtype* bottom_diff = bottom[i]->mutable_gpu_diff();
+            CUDNN_CHECK(
+                        cudnnConvolutionForward(handle_[2 * this->group_ + g],
+                                                cudnn::dataType<Dtype>::one,
+                                                top_descs_[i],
+                                                top_diff + top_offset_ * g,
+                                                filter_desc_,
+                                                weight + this->weight_offset_ * g,
+                                                conv_descs_[i],
+                                                fwd_algo_[i],
+                                                workspace[2 * this->group_ + g],
+                                                workspace_fwd_sizes_[i],
+                                                cudnn::dataType<Dtype>::zero,
+                                                bottom_descs_[i],
+                                                bottom_diff + bottom_offset_ * g));
+          }
         }
-        Dtype* bottom_diff = bottom[i]->mutable_gpu_diff();
-        CUDNN_CHECK(
-            cudnnConvolutionForward(handle_[2 * this->group_ + g],
-                                    cudnn::dataType<Dtype>::one,
-                                    top_descs_[i],
-                                    top_diff + top_offset_ * g,
-                                    filter_desc_,
-                                    weight + this->weight_offset_ * g,
-                                    conv_descs_[i],
-                                    fwd_algo_[i],
-                                    workspace[2 * this->group_ + g],
-                                    workspace_fwd_sizes_[i],
-                                    cudnn::dataType<Dtype>::zero,
-                                    bottom_descs_[i],
-                                    bottom_diff + bottom_offset_ * g));
-      }
-    }
 
-    // Synchronize the work across groups, each of which went into its own
-    // stream, by launching an empty kernel into the default (null) stream.
-    // NOLINT_NEXT_LINE(whitespace/operators)
-    sync_deconv_groups<<<1, 1>>>();
+        // Synchronize the work across groups, each of which went into its own
+        // stream, by launching an empty kernel into the default (null) stream.
+        // NOLINT_NEXT_LINE(whitespace/operators)
+        sync_deconv_groups<<<1, 1>>>();
+#if CUDNN_VERSION_MIN(7,0,0)
+      }
+    else
+      {
+        if (this->bias_term_ && this->param_propagate_down_[1]) {
+          CUDNN_CHECK(cudnnConvolutionBackwardBias(handle_[0],
+                                                   cudnn::dataType<Dtype>::one,
+                                                   top_descs_[i],
+                                                   top_diff,
+                                                   cudnn::dataType<Dtype>::one,
+                                                   bias_desc_,
+                                                   bias_diff));
+      }
+
+        // Gradient w.r.t. weights.
+        if (this->param_propagate_down_[0]) {
+          const Dtype* bottom_data = bottom[i]->gpu_data();
+          CUDNN_CHECK(cudnnConvolutionBackwardFilter(
+                                                     handle_[0],
+                                                     cudnn::dataType<Dtype>::one,
+                                                     top_descs_[i],
+                                                     top_diff,
+                                                     bottom_descs_[i],
+                                                     bottom_data,
+                                                     conv_descs_[i],
+                                                     bwdFilterPerf_[i].algo,
+                                                     workspaceData,
+                                                     bwdFilterPerf_[i].memory,
+                                                     cudnn::dataType<Dtype>::one,
+                                                     filter_desc_,
+                                                     weight_diff));
+          }
+
+          // Gradient w.r.t. bottom data.
+        if (propagate_down[i]) {
+          if (weight == NULL) {
+            weight = this->blobs_[0]->gpu_data();
+          }
+          Dtype* bottom_diff = bottom[i]->mutable_gpu_diff();
+          CUDNN_CHECK(cudnnConvolutionForward(handle_[0],
+                                              cudnn::dataType<Dtype>::one,
+                                              top_descs_[i],
+                                              top_diff,
+                                              filter_desc_,
+                                              weight,
+                                              conv_descs_[i],
+                                              fwdPerf_[i].algo,
+                                              workspaceData,
+                                              fwdPerf_[i].memory,
+                                              cudnn::dataType<Dtype>::zero,
+                                              bottom_descs_[i],
+                                              bottom_diff));
+        }
+      }
+#endif
   }
 }
 

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -1045,6 +1045,20 @@ message ConvolutionParameter {
   // implementation; for input blobs with num_axes != 2, this option is
   // ignored and the ND implementation will be used.)
   optional bool force_nd_im2col = 17 [default = false];
+
+
+  // older cuddn implementation (< 7.0) use multiple handles to parallelize computation on
+  // older cudnn lib. This behavior uses a lot of memory that is not fully released
+  // setting cudnn_multiple_handle to false use only one handle and rely on cudnn for
+  // parallel opimization
+  // newer cudnn (>= 7.0) should not change the default
+  // on older cudnn , this option is automatically  set to true
+  enum CudnnFlavor {
+    SINGLE_HANDLE = 0;
+    MULTIPLE_HANDLES = 1;
+    MIN_MEMORY = 2;
+  }
+  optional CudnnFlavor cudnn_flavor = 19 [default = MULTIPLE_HANDLES];
 }
 
 message CropParameter {


### PR DESCRIPTION
this PR is an in-deep rewrite of cudnn_conv_layer, for cudnn >= 7.0 , inspired from pytorch
if building agains cudnn <7.0, old implementation is used

MOTIVATION: cudnn handles should not be allocated and destroyed at will, as in bvlc/caffe implementation, they leak a _lot_ of GPU memory (at least view from other processes, same process can reuse memory) 

- it uses native cudnn group convolution instead of caffe hand written one, available from cudnn 7.0
- also uses getConvolution[Forward|Backward[Filter|Data]]Algorithm_v7 , also available from cudnn 7.0
- add convolution_param.cudnn_multiple_handles  in caffe.proto parameters. defaults to false (new implementation), can be set to true to get older implementation. This option is not used is case of cudnn < 7.0, older implementation is the only possible

working, test ok