### PR TITLE
force memory limit when auto selecting algo whithin  conv_layers/cudnn/single_handle

### DIFF
--- a/include/caffe/layers/cudnn_conv_layer.hpp
+++ b/include/caffe/layers/cudnn_conv_layer.hpp
@@ -67,9 +67,6 @@ class CuDNNConvolutionLayer : public ConvolutionLayer<Dtype> {
   cudnnHandle_t* handle_;
   cudaStream_t*  stream_;
 
-
-
-
   // algorithms for forward and backwards convolutions
   cudnnConvolutionFwdAlgo_t *fwd_algo_;
   cudnnConvolutionBwdFilterAlgo_t *bwd_filter_algo_;
@@ -77,11 +74,6 @@ class CuDNNConvolutionLayer : public ConvolutionLayer<Dtype> {
 
   bool multiple_handles_;
   bool min_memory_;
-#if CUDNN_VERSION_MIN(7,0,0)
-  std::vector<cudnnConvolutionFwdAlgoPerf_t> fwdPerf_;
-  std::vector<cudnnConvolutionBwdFilterAlgoPerf_t> bwdFilterPerf_;
-  std::vector<cudnnConvolutionBwdDataAlgoPerf_t> bwdDataPerf_;
-#endif
 
   vector<cudnnTensorDescriptor_t> bottom_descs_, top_descs_;
   cudnnTensorDescriptor_t    bias_desc_;

--- a/src/caffe/layers/cudnn_conv_layer.cu
+++ b/src/caffe/layers/cudnn_conv_layer.cu
@@ -54,8 +54,9 @@ void CuDNNConvolutionLayer<Dtype>::Forward_gpu(
                                             bottom_descs_[i], bottom_data,
                                             filter_desc_, weight,
                                             conv_descs_[i],
-                                            fwdPerf_[i].algo, workspaceData,
-                                            fwdPerf_[i].memory,
+                                            fwd_algo_[i],
+                                            workspaceData,
+                                            workspace_fwd_sizes_[i],
                                             cudnn::dataType<Dtype>::zero,
                                             top_descs_[i], top_data));
 
@@ -164,8 +165,9 @@ void CuDNNConvolutionLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
                                                        bottom_descs_[i], bottom_data,
                                                        top_descs_[i],    top_diff,
                                                        conv_descs_[i],
-                                                       bwdFilterPerf_[i].algo, workspaceData,
-                                                       bwdFilterPerf_[i].memory,
+                                                       bwd_filter_algo_[i],
+                                                       workspaceData,
+                                                       workspace_bwd_filter_sizes_[i],
                                                        cudnn::dataType<Dtype>::one,
                                                        filter_desc_, weight_diff));
           }
@@ -182,8 +184,9 @@ void CuDNNConvolutionLayer<Dtype>::Backward_gpu(const vector<Blob<Dtype>*>& top,
                                                      filter_desc_, weight,
                                                      top_descs_[i], top_diff,
                                                      conv_descs_[i],
-                                                     bwdDataPerf_[i].algo, workspaceData,
-                                                     bwdDataPerf_[i].memory,
+                                                     bwd_data_algo_[i],
+                                                     workspaceData,
+                                                     workspace_bwd_data_sizes_[i],
                                                      cudnn::dataType<Dtype>::zero,
                                                      bottom_descs_[i], bottom_diff));
           }


### PR DESCRIPTION
when cudnn selects algo with new heuristics, it is not possible to force an upper workspace limit, so it is possible for previous implementation to select  algorithms that are ok independently for each conv layer, , but the sum of the memory requirement for external workspaces do not fit. 
this PR restores the ability to fix individual memory limit for each conv layer, so that the sum of memory requirement is controlled. 
for instance for refineddet_512, we have
CAFFE/CUDA implementation requires 7.1G
CUDNN/multiple_handle implementation requires 5.7G (includes upper bound for external workspace)
CUDNN/single_handle requires 4.9G (same upper bound for external workspace as multiple_handle)
CUDNN/min_memory requires 4.6G (force zero external workspace everywhere)