### PR TITLE
fixing geometric transform activation

### DIFF
--- a/src/caffe/data_transformer.cpp
+++ b/src/caffe/data_transformer.cpp
@@ -694,6 +694,12 @@ void DataTransformer<Dtype>::GeometryImage(const AnnotatedDatum& anno_datum,
     // cv::imwrite("/tmp/cv.jpg", cv_img);
     // cv::imwrite("/tmp/geom.jpg", geom_img);
 
+    if (geom_img.empty())
+      {
+	LOG(WARNING) << "failed geometry augmentation on image"; // no image name since from datum
+	geom_img = cv_img;
+      }
+    
     EncodeCVMatToDatum(geom_img, "jpg", geometry_anno_datum->mutable_datum());
     return;
 #else

--- a/src/caffe/layers/annotated_data_layer.cpp
+++ b/src/caffe/layers/annotated_data_layer.cpp
@@ -162,6 +162,12 @@ void AnnotatedDataLayer<Dtype>::load_batch(Batch<Dtype>* batch) {
       } else {
         expand_datum = &distort_datum;
       }
+      if (expand_datum &&
+	  (expand_datum->datum().width() == 0 || expand_datum->datum().height() == 0))
+	{
+	  LOG(WARNING) << "Expand augmentation failure";
+	  expand_datum = &distort_datum;
+	}
     } else {
       if (transform_param.has_expand_param()) {
         expand_datum = new AnnotatedDatum();
@@ -172,7 +178,8 @@ void AnnotatedDataLayer<Dtype>::load_batch(Batch<Dtype>* batch) {
     }
 
     AnnotatedDatum* geometry_datum = NULL;
-    if (transform_param.has_geometry_param())
+    if (transform_param.has_geometry_param()
+	&& transform_param.geometry_param().prob() > 0.0)
       {
         geometry_datum = new AnnotatedDatum();
         this->data_transformer_->GeometryImage(*expand_datum, geometry_datum);
@@ -181,7 +188,7 @@ void AnnotatedDataLayer<Dtype>::load_batch(Batch<Dtype>* batch) {
       {
         geometry_datum = expand_datum;
       }
-
+    
     AnnotatedDatum* rotate_datum = NULL;
     if (transform_param.rotate()) {
       rotate_datum = new AnnotatedDatum();
@@ -276,7 +283,8 @@ void AnnotatedDataLayer<Dtype>::load_batch(Batch<Dtype>* batch) {
     if (transform_param.rotate()) {
       delete rotate_datum;
     }
-    if (transform_param.has_geometry_param())
+    if (transform_param.has_geometry_param()
+	&& transform_param.geometry_param().prob())
       {
         delete geometry_datum;
       }


### PR DESCRIPTION
Wrong activation + crashes on some geometric transforms on large expanded images (4kx4k).