### PR TITLE
using OMP over SSD data augmentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -440,8 +440,8 @@ CXXFLAGS += -MMD -MP -std=c++11
 # Complete build flags.
 #COMMON_FLAGS += $(foreach includedir,$(INCLUDE_DIRS),-isystem $(includedir))
 COMMON_FLAGS += $(foreach includedir,$(INCLUDE_DIRS),-I$(includedir)) -std=c++11
-CXXFLAGS += -pthread -fPIC $(COMMON_FLAGS) $(WARNINGS)
-NVCCFLAGS += -D_FORCE_INLINES -ccbin=$(CXX) -Xcompiler -fPIC $(COMMON_FLAGS)
+CXXFLAGS += -pthread -fPIC $(COMMON_FLAGS) $(WARNINGS) -fopenmp
+NVCCFLAGS += -D_FORCE_INLINES -ccbin=$(CXX) -Xcompiler -fPIC -Xcompiler -fopenmp $(COMMON_FLAGS)
 # mex may invoke an older gcc that is too liberal with -Wuninitalized
 MATLAB_CXXFLAGS := $(CXXFLAGS) -Wno-uninitialized
 LINKFLAGS += -pthread -fPIC $(COMMON_FLAGS) $(WARNINGS)

--- a/include/caffe/layers/annotated_data_layer.hpp
+++ b/include/caffe/layers/annotated_data_layer.hpp
@@ -36,6 +36,8 @@ class AnnotatedDataLayer : public BasePrefetchingDataLayer<Dtype> {
   AnnotatedDatum_AnnotationType anno_type_;
   vector<BatchSampler> batch_samplers_;
   string label_map_file_;
+
+  vector<shared_ptr<Blob<Dtype> > > transformed_data_array_;
 };
 
 }  // namespace caffe


### PR DESCRIPTION
OpenMP over the batch size loop for data augmentation. Tested, speeds things up a bit at training time.

Similar trick could be applicable to the `DenseImageDataLayer` as well for training segmentation models.