### PR TITLE
fix: support for CUDNN v8 (convolutions / deconvolutions)

### DIFF
--- a/Makefile.config.gpu.cudnn
+++ b/Makefile.config.gpu.cudnn
@@ -11,7 +11,7 @@ USE_LMDB := 1
 # CPU_ONLY := 1
 
 # Uncomment if you're using OpenCV 3
-#OPENCV_VERSION := 3
+OPENCV_VERSION := 3
 
 # To customize your choice of compiler, uncomment and set the following.
 # N.B. the default for Linux is g++ and the default for OSX is clang++

--- a/include/caffe/layers/cudnn_conv_layer.hpp
+++ b/include/caffe/layers/cudnn_conv_layer.hpp
@@ -38,10 +38,13 @@ class CuDNNConvolutionLayer : public ConvolutionLayer<Dtype> {
         multiple_handles_ = false;
         min_memory_ = false;
         break;
+#if CUDNN_VERSION_MIN(8,0,0)
+#else
       case ConvolutionParameter::MULTIPLE_HANDLES:
         multiple_handles_ = true;
         min_memory_ = false;
         break;
+#endif
       case ConvolutionParameter::MIN_MEMORY:
         multiple_handles_ = false;
         min_memory_ = true;
@@ -71,7 +74,8 @@ class CuDNNConvolutionLayer : public ConvolutionLayer<Dtype> {
   cudnnConvolutionFwdAlgo_t *fwd_algo_;
   cudnnConvolutionBwdFilterAlgo_t *bwd_filter_algo_;
   cudnnConvolutionBwdDataAlgo_t *bwd_data_algo_;
-
+  bool algo_set_ = false;
+  
   bool multiple_handles_;
   bool min_memory_;
 

--- a/include/caffe/layers/cudnn_deconv_layer.hpp
+++ b/include/caffe/layers/cudnn_deconv_layer.hpp
@@ -33,9 +33,12 @@ class CuDNNDeconvolutionLayer : public DeconvolutionLayer<Dtype> {
         multiple_handles_ = false;
         min_memory_ = false;
         break;
+#if CUDNN_VERSION_MIN(8,0,0)
+#else
       case ConvolutionParameter::MULTIPLE_HANDLES:
         multiple_handles_ = true;
         break;
+#endif
       case ConvolutionParameter::MIN_MEMORY:
         multiple_handles_ = false;
         min_memory_ = true;
@@ -74,7 +77,8 @@ class CuDNNDeconvolutionLayer : public DeconvolutionLayer<Dtype> {
   std::vector<cudnnConvolutionBwdFilterAlgoPerf_t> bwdFilterPerf_;
   std::vector<cudnnConvolutionBwdDataAlgoPerf_t> bwdDataPerf_;
 #endif
-
+  bool algo_set_ = false;
+  
   vector<cudnnTensorDescriptor_t> bottom_descs_, top_descs_;
   cudnnTensorDescriptor_t bias_desc_;
   cudnnFilterDescriptor_t filter_desc_;

--- a/include/caffe/util/cudnn.hpp
+++ b/include/caffe/util/cudnn.hpp
@@ -51,6 +51,10 @@ inline const char* cudnnGetErrorString(cudnnStatus_t status) {
   case CUDNN_STATUS_RUNTIME_IN_PROGRESS:
     return "CUDNN_STATUS_RUNTIME_IN_PROGRESS";
 #endif
+#if CUDNN_VERSION_MIN(8, 0, 0)
+  case CUDNN_STATUS_VERSION_MISMATCH:
+    return "CUDNN_STATUS_VERSION_MISMATCH";
+#endif
   }
   return "Unknown cudnn status";
 }


### PR DESCRIPTION
This PR adds the following elements to convolutions and deconvolutions operations with CUDNN:
- support for CUDNN v8
- the 'best' algorithm returned by CUDNN is now only checked once at layer creation/setup and stays fixed until destruction of the layer
- `CUDNN_MULTIPLE_HANDLES` does not apply anymore to CUDNN v8, I did remove it as the memory usage was too large to fit a small network on a Jetson NX.