### PR TITLE
fix: for CUDA 11.1, caffe default on our Cudnn MIN_MEMORY handle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -436,11 +436,11 @@ LIBRARY_DIRS += $(BLAS_LIB)
 LIBRARY_DIRS += $(LIB_BUILD_DIR)
 
 # Automatic dependency generation (nvcc is handled separately)
-CXXFLAGS += -MMD -MP -std=c++11
+CXXFLAGS += -MMD -MP -std=c++14
 
 # Complete build flags.
 #COMMON_FLAGS += $(foreach includedir,$(INCLUDE_DIRS),-isystem $(includedir))
-COMMON_FLAGS += $(foreach includedir,$(INCLUDE_DIRS),-I$(includedir)) -std=c++11
+COMMON_FLAGS += $(foreach includedir,$(INCLUDE_DIRS),-I$(includedir)) -std=c++14
 CXXFLAGS += -pthread -fPIC $(COMMON_FLAGS) $(WARNINGS) -fopenmp
 NVCCFLAGS += -D_FORCE_INLINES -ccbin=$(CXX) -Xcompiler -fPIC -Xcompiler -fopenmp $(COMMON_FLAGS)
 # mex may invoke an older gcc that is too liberal with -Wuninitalized

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -1078,7 +1078,7 @@ message ConvolutionParameter {
     MULTIPLE_HANDLES = 1;
     MIN_MEMORY = 2;
   }
-  optional CudnnFlavor cudnn_flavor = 19 [default = MULTIPLE_HANDLES];
+  optional CudnnFlavor cudnn_flavor = 19 [default = MIN_MEMORY];
 }
 
 message CropParameter {


### PR DESCRIPTION
Other CUDNN handles with Caffe lead to unit tests failing, even with `batch_size` set to 1. There must be some interaction with CUDNN and CUDA 11.1 that has become the norm, and that uses much more memory with other handle configurations.

For this reason this PR forces MIN_MEMORY as the default, and I believe this is the right thing to do in all cases, and I've started defaulting to it a while ago through the API. The main reason is we want training/inference to have the highest changes of starting in most cases, then other optimizations can be tried such as modifying the CUDNN scheme to squeeze a bit more performances while using more memory.